### PR TITLE
add health check for db connection

### DIFF
--- a/src/InnovateFuture.Api/InnovateFuture.Api.csproj
+++ b/src/InnovateFuture.Api/InnovateFuture.Api.csproj
@@ -19,6 +19,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="8.0.2" />
+    <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.1" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
@@ -26,6 +28,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.11" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/src/InnovateFuture.Api/appsettings.Development.json.sample
+++ b/src/InnovateFuture.Api/appsettings.Development.json.sample
@@ -7,7 +7,7 @@
   },
   "DBConnection": "Host=localhost;Database=InnovateFuture;Username=postgres;Password=password",
   "JWTConfig": {
-      "SecrectKey": "SecrectKeyExample",
+      "SecretKey": "SecretKeyExample",
       "Issuer": "innovateFuture",
       "Audience": "innovateFuture",
       "ExpireSeconds": 7200

--- a/src/InnovateFuture.Application/Services/Security/CreateTokenService.cs
+++ b/src/InnovateFuture.Application/Services/Security/CreateTokenService.cs
@@ -22,7 +22,7 @@ public class CreateTokenService
         foreach (var item in playBody)
             claims.Add(new Claim(item.Key, item.Value));
 
-        var key = new SymmetricSecurityKey(Encoding.ASCII.GetBytes(_jWTConfig.SecrectKey));
+        var key = new SymmetricSecurityKey(Encoding.ASCII.GetBytes(_jWTConfig.SecretKey));
         var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
 
         var token = new JwtSecurityToken(

--- a/src/InnovateFuture.Infrastructure/Configs/JWTConfig.cs
+++ b/src/InnovateFuture.Infrastructure/Configs/JWTConfig.cs
@@ -3,7 +3,7 @@ namespace InnovateFuture.Infrastructure.Configs;
 public class JWTConfig
 {
     public const string Section = "JWTConfig";
-    public string SecrectKey { get; set; }
+    public string SecretKey { get; set; }
     public string Issuer { get; set; }
     public string Audience { get; set; }
     public int ExpireSeconds { get; set; }

--- a/src/InnovateFuture.Infrastructure/Configs/JWTInitExtension.cs
+++ b/src/InnovateFuture.Infrastructure/Configs/JWTInitExtension.cs
@@ -20,7 +20,7 @@ public static class JWTInitExtension
                     ValidAudience = jWTConfig.Audience,
                     ValidateAudience = true,
                     ValidateLifetime = true,
-                    IssuerSigningKey = new SymmetricSecurityKey(Encoding.ASCII.GetBytes(jWTConfig.SecrectKey))
+                    IssuerSigningKey = new SymmetricSecurityKey(Encoding.ASCII.GetBytes(jWTConfig.SecretKey))
                 };
             });
     }


### PR DESCRIPTION
This PR adds a PostgreSQL health check using Entity Framework (EF) and exposes a /health endpoint. The endpoint allows third-party services (e.g., load balancers) to monitor the application’s health status.

Changes Made
	•	Configured PostgreSQL health check via EF to validate database connectivity.
	•	Exposed a /health endpoint to report the application’s health status:
	•	Returns 200 OK when the database connection is healthy.
	•	Returns 503 Service Unavailable when the database connection is unhealthy.

Testing Method

•	Simulated a healthy state with correct database credentials.
•	Simulated an unhealthy state by intentionally setting an incorrect database password to verify the endpoint’s response.

Related Ticket

[JIRA Ticket: IF-64](https://dext.atlassian.net/jira/software/c/projects/IF/boards/26?selectedIssue=IF-64)