### PR TITLE
Bugfix/IF-78: Proper Error Handling for Invalid User Request Body

### DIFF
--- a/src/InnovateFuture.Api/Exceptions/IFAggregateNotInitializedException.cs
+++ b/src/InnovateFuture.Api/Exceptions/IFAggregateNotInitializedException.cs
@@ -1,6 +1,0 @@
-namespace InnovateFuture.Api.Exceptions;
-
-public class IFAggregateNotInitializedException: Exception
-{
-    public IFAggregateNotInitializedException(string message) : base(message) { }
-}

--- a/src/InnovateFuture.Api/Exceptions/IFBusinessRuleViolationException.cs
+++ b/src/InnovateFuture.Api/Exceptions/IFBusinessRuleViolationException.cs
@@ -1,8 +1,0 @@
-namespace InnovateFuture.Api.Exceptions;
-
-
-public class IFBusinessRuleViolationException:Exception
-{
-    public IFBusinessRuleViolationException(string message):base(message)
-    {}
-}

--- a/src/InnovateFuture.Api/Exceptions/IFConcurrencyException.cs
+++ b/src/InnovateFuture.Api/Exceptions/IFConcurrencyException.cs
@@ -1,7 +1,0 @@
-namespace InnovateFuture.Api.Exceptions;
-
-
-public class IFConcurrencyException : Exception
-{
-    public IFConcurrencyException(string message) : base(message) { }
-}

--- a/src/InnovateFuture.Api/Exceptions/IFDatabaseException.cs
+++ b/src/InnovateFuture.Api/Exceptions/IFDatabaseException.cs
@@ -1,7 +1,0 @@
-namespace InnovateFuture.Api.Exceptions;
-
-
-public class IFDatabaseException: Exception
-{
-    public IFDatabaseException(string message):base(message){}
-}

--- a/src/InnovateFuture.Api/Exceptions/IFDomainValidationException.cs
+++ b/src/InnovateFuture.Api/Exceptions/IFDomainValidationException.cs
@@ -1,9 +1,0 @@
-namespace InnovateFuture.Api.Exceptions;
-
-
-public class IFDomainValidationException: Exception
-{
-    public IFDomainValidationException(string message) : base(message)
-    {
-    }
-}

--- a/src/InnovateFuture.Api/Exceptions/IFEntityNotFoundException.cs
+++ b/src/InnovateFuture.Api/Exceptions/IFEntityNotFoundException.cs
@@ -1,8 +1,0 @@
-namespace InnovateFuture.Api.Exceptions;
-
-
-public class IFEntityNotFoundException:Exception
-{
-    public IFEntityNotFoundException(string entityName, object key)
-        : base($"{entityName} with key {key} was not found.") { }
-}

--- a/src/InnovateFuture.Api/Exceptions/IFExternalServiceException.cs
+++ b/src/InnovateFuture.Api/Exceptions/IFExternalServiceException.cs
@@ -1,7 +1,0 @@
-namespace InnovateFuture.Api.Exceptions;
-
-
-public class IFExternalServiceException: Exception
-{
-    public IFExternalServiceException(string message):base(message){}
-}

--- a/src/InnovateFuture.Api/Exceptions/IFPolicyViolationException.cs
+++ b/src/InnovateFuture.Api/Exceptions/IFPolicyViolationException.cs
@@ -1,7 +1,0 @@
-namespace InnovateFuture.Api.Exceptions;
-
-
-public class IFPolicyViolationException : Exception
-{
-    public IFPolicyViolationException(string message) : base(message) { }
-}

--- a/src/InnovateFuture.Api/Exceptions/IFUnauthorizedActionException.cs
+++ b/src/InnovateFuture.Api/Exceptions/IFUnauthorizedActionException.cs
@@ -1,7 +1,0 @@
-namespace InnovateFuture.Api.Exceptions;
-
-
-public class IFUnauthorizedActionException : Exception
-{
-    public IFUnauthorizedActionException(string message) : base(message) { }
-}

--- a/src/InnovateFuture.Api/Filters/ModelValidationFilter.cs
+++ b/src/InnovateFuture.Api/Filters/ModelValidationFilter.cs
@@ -1,0 +1,27 @@
+﻿using InnovateFuture.Api.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace InnovateFuture.Api.Filters;
+
+    public class ModelValidationFilter : ActionFilterAttribute
+    {
+        public override void OnActionExecuting(ActionExecutingContext context)
+        {
+            if (!context.ModelState.IsValid)
+            {
+                var errors = context.ModelState.Values
+                    .SelectMany(v => v.Errors)
+                    .Select(e => e.ErrorMessage)
+                    .ToList();
+
+                var response = new CommonResponse<object>
+                {
+                    IsSuccess = false,
+                    Errors = errors
+                };
+
+                context.Result = new BadRequestObjectResult(response);
+            }
+        }
+    }

--- a/src/InnovateFuture.Api/Middleware/GlobalExceptionMiddleware.cs
+++ b/src/InnovateFuture.Api/Middleware/GlobalExceptionMiddleware.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
-using InnovateFuture.Api.Exceptions;
 using InnovateFuture.Api.Models;
+using InnovateFuture.Domain.Exceptions;
+using InnovateFuture.Infrastructure.Exceptions;
 
 namespace InnovateFuture.Api.Middleware;
 
@@ -38,7 +39,6 @@ public class GlobalExceptionMiddleware
         {
             FluentValidation.ValidationException validationException =>
                 HandleValidationException(response, validationException),
-            IFAggregateNotInitializedException => StatusCodes.Status400BadRequest,
             IFBusinessRuleViolationException => StatusCodes.Status400BadRequest,
             IFConcurrencyException => StatusCodes.Status409Conflict,
             IFDatabaseException => StatusCodes.Status500InternalServerError,

--- a/src/InnovateFuture.Api/Program.cs
+++ b/src/InnovateFuture.Api/Program.cs
@@ -36,7 +36,7 @@ namespace InnovateFuture.Api
             {
                 //global filter register, working for all actions
                 option.Filters.Add<CommonResultFilter>();
-                // option.Filters.Add<ExceptionFilter>();
+                option.Filters.Add<ModelValidationFilter>();
             }).AddJsonOptions(options =>
             {
                 options.JsonSerializerOptions.ReferenceHandler = System.Text.Json.Serialization.ReferenceHandler.IgnoreCycles;


### PR DESCRIPTION
This PR fixed a bug causing 500 Internal Server Error for malformed user request bodies, now returning 400 Bad Request.

Key Changes

- Removed redundant exceptions from the API layer to resolve conflicts with the domain and infrastructure layers.
- Add a model filter to catch model validation.

Testing Method
- Manual testing to get 400 status code while include invalid request format.

Related Ticket
[JIRA Ticket: IF-78](https://dext.atlassian.net/jira/software/c/projects/IF/boards/26?selectedIssue=IF-78)