### PR TITLE
Feature/if 57 table profile

### DIFF
--- a/src/InnovateFuture.Api/Program.cs
+++ b/src/InnovateFuture.Api/Program.cs
@@ -66,7 +66,7 @@ namespace InnovateFuture.Api
             builder.Services.AddDbContext<ApplicationDbContext>(
                 dbContextOptions => dbContextOptions
                     .UseNpgsql(connectionString,
-                        npgsqlOptions => npgsqlOptions.SetPostgresVersion(new Version(17, 2)))
+                        npgsqlOptions => npgsqlOptions.SetPostgresVersion(new Version(16, 6)))
                     // The following three options help with debugging, but should
                     // be changed or removed for production.
                     .LogTo(Console.WriteLine, Microsoft.Extensions.Logging.LogLevel.Information)

--- a/src/InnovateFuture.Domain/Entities/Profile.cs
+++ b/src/InnovateFuture.Domain/Entities/Profile.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace InnovateFuture.Domain.Entities
+{
+    public class Profile
+    {
+        // Key
+        public long ProfileId { get; set; }
+
+        // Foreigh Key（not define navigate key）
+        public long OrgId { get; set; }  // Organisation Foreign key
+        public long RoleId { get; set; } // Role Foreign key
+        public long UserId { get; set; } // User Foreign key
+
+        // Foreign key: Supervisor（maybe point to the other  Profile）
+        public long? SupervisorId { get; set; }
+
+        // basis attribute
+        public string Name { get; set; }
+        public string Email { get; set; }
+        public string Phone { get; set; }
+        public string Avatar { get; set; }
+        public string ExtraFields { get; set; }
+        public bool IsActive { get; set; }
+
+        // navigation attribute
+    }
+}

--- a/src/InnovateFuture.Domain/Entities/UserProfile.cs
+++ b/src/InnovateFuture.Domain/Entities/UserProfile.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace InnovateFuture.Domain.Entities
 {
-    public class Profile
+    public class UserProfile
     {
         // Key
         public long ProfileId { get; set; }

--- a/src/InnovateFuture.Infrastructure/Common/Persistence/ApplicationDbContext.cs
+++ b/src/InnovateFuture.Infrastructure/Common/Persistence/ApplicationDbContext.cs
@@ -7,6 +7,8 @@ public class ApplicationDbContext : DbContext
     public DbSet<Order> Orders { get; set; }
     public DbSet<OrderItem> OrderItems { get; set; }
 
+    public DbSet<Profile> profiles { get; set; }
+
     public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options)
     {
     }

--- a/src/InnovateFuture.Infrastructure/Common/Persistence/ApplicationDbContext.cs
+++ b/src/InnovateFuture.Infrastructure/Common/Persistence/ApplicationDbContext.cs
@@ -7,7 +7,7 @@ public class ApplicationDbContext : DbContext
     public DbSet<Order> Orders { get; set; }
     public DbSet<OrderItem> OrderItems { get; set; }
 
-    public DbSet<Profile> profiles { get; set; }
+    public DbSet<UserProfile> profiles { get; set; }
 
     public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options)
     {

--- a/src/InnovateFuture.Infrastructure/Migrations/20241222035044_UserProfileMigrationMsg.Designer.cs
+++ b/src/InnovateFuture.Infrastructure/Migrations/20241222035044_UserProfileMigrationMsg.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using InnovateFuture.Infrastructure.Common.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace InnovateFuture.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241222035044_UserProfileMigrationMsg")]
+    partial class UserProfileMigrationMsg
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/InnovateFuture.Infrastructure/Migrations/20241222035044_UserProfileMigrationMsg.cs
+++ b/src/InnovateFuture.Infrastructure/Migrations/20241222035044_UserProfileMigrationMsg.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace InnovateFuture.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class UserProfileMigrationMsg : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "profiles",
+                columns: table => new
+                {
+                    ProfileId = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    OrgId = table.Column<long>(type: "bigint", nullable: false),
+                    RoleId = table.Column<long>(type: "bigint", nullable: false),
+                    UserId = table.Column<long>(type: "bigint", nullable: false),
+                    SupervisorId = table.Column<long>(type: "bigint", nullable: true),
+                    Name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    Email = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    Phone = table.Column<string>(type: "text", nullable: false),
+                    Avatar = table.Column<string>(type: "text", nullable: false),
+                    ExtraFields = table.Column<string>(type: "text", nullable: false),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_profiles", x => x.ProfileId);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "profiles");
+        }
+    }
+}

--- a/src/InnovateFuture.Infrastructure/Profiles/Persistence/Interfaces/IProfileRepository.cs
+++ b/src/InnovateFuture.Infrastructure/Profiles/Persistence/Interfaces/IProfileRepository.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace InnovateFuture.Infrastructure.Profiles.Persistence.Interfaces
+{
+    public interface IProfileRepository
+    {
+        //Task<Profile> GetByIdAsync(long profileId);
+        //Task AddAsync(Profile profile);
+        //Task UpdateAsync(Profile profile);
+        //Task DeleteAsync(long profileId);
+    }
+}

--- a/src/InnovateFuture.Infrastructure/Profiles/Persistence/Modelconfigs/ProfileConfig.cs
+++ b/src/InnovateFuture.Infrastructure/Profiles/Persistence/Modelconfigs/ProfileConfig.cs
@@ -1,0 +1,27 @@
+﻿using InnovateFuture.Domain.Entities;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace InnovateFuture.Infrastructure.Profiles.Persistence.Modelconfigs
+{
+    public class ProfileConfiguration : IEntityTypeConfiguration<Profile>
+    {
+        public void Configure(EntityTypeBuilder<Profile> builder)
+        {
+            builder.HasKey(p => p.ProfileId);
+
+            builder.Property(p => p.Name)
+                   .HasMaxLength(100)
+                   .IsRequired();
+
+            builder.Property(p => p.Email)
+                   .HasMaxLength(100)
+                   .IsRequired();
+        }
+    }
+}

--- a/src/InnovateFuture.Infrastructure/Profiles/Persistence/Modelconfigs/ProfileConfig.cs
+++ b/src/InnovateFuture.Infrastructure/Profiles/Persistence/Modelconfigs/ProfileConfig.cs
@@ -9,9 +9,9 @@ using System.Threading.Tasks;
 
 namespace InnovateFuture.Infrastructure.Profiles.Persistence.Modelconfigs
 {
-    public class ProfileConfiguration : IEntityTypeConfiguration<Profile>
+    public class ProfileConfiguration : IEntityTypeConfiguration<UserProfile>
     {
-        public void Configure(EntityTypeBuilder<Profile> builder)
+        public void Configure(EntityTypeBuilder<UserProfile> builder)
         {
             builder.HasKey(p => p.ProfileId);
 

--- a/src/InnovateFuture.Infrastructure/Profiles/Persistence/Repositories/ProfileRepository.cs
+++ b/src/InnovateFuture.Infrastructure/Profiles/Persistence/Repositories/ProfileRepository.cs
@@ -1,0 +1,49 @@
+﻿using InnovateFuture.Infrastructure.Common.Persistence;
+using InnovateFuture.Infrastructure.Profiles.Persistence.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace InnovateFuture.Infrastructure.Profiles.Persistence.Repositories
+{
+    public class ProfileRepository : IProfileRepository
+    {
+
+        private readonly ApplicationDbContext _dbContext;
+
+        public ProfileRepository(ApplicationDbContext dbContext)
+        {
+            _dbContext = dbContext;
+        }
+
+        //CRUD
+        //public async Task<Profile> GetByIdAsync(long profileId)
+        //{
+        //    return await _dbContext.Profiles.FindAsync(profileId);
+        //}
+
+        //public async Task AddAsync(Profile profile)
+        //{
+        //    await _dbContext.Profiles.AddAsync(profile);
+        //    await _dbContext.SaveChangesAsync();
+        //}
+
+        //public async Task UpdateAsync(Profile profile)
+        //{
+        //    _dbContext.Profiles.Update(profile);
+        //    await _dbContext.SaveChangesAsync();
+        //}
+
+        //public async Task DeleteAsync(long profileId)
+        //{
+        //    var profile = await _dbContext.Profiles.FindAsync(profileId);
+        //    if (profile != null)
+        //    {
+        //        _dbContext.Profiles.Remove(profile);
+        //        await _dbContext.SaveChangesAsync();
+        //    }
+        //}
+    }
+}


### PR DESCRIPTION
Add the profile entity and migration success in local progresql , due to  'Profile' is an ambiguous reference between 'AutoMapper.Profile' and 'InnovateFuture.Domain.Entities.Profile', so rename the ER diagram Profile to UserProfile