### PR TITLE
refactor: make cognitouuid nullable and orgid nullable in db

### DIFF
--- a/src/InnovateFuture.Api/Controllers/UsersController/CreateUserRequest.cs
+++ b/src/InnovateFuture.Api/Controllers/UsersController/CreateUserRequest.cs
@@ -2,14 +2,12 @@ namespace InnovateFuture.Api.Controllers.UsersController;
 
 public class CreateUserRequest
 {
-    public Guid CognitoUuid { get; set; }
     public Guid OrgId { get; set; }
     public Guid RoleId { get; set; }
     public string Email { get; set; }
     public Guid? InvitedBy { get; set; }
     public Guid? SupervisedBy { get; set; }
-    public string? GivenName { get; set; }
-    public string? FamilyName { get; set; }
+    public string? FullName { get; set; }
     public string? Phone { get; set; }
     public DateTime? Birthday { get; set; } 
 }

--- a/src/InnovateFuture.Api/Controllers/UsersController/GetUserResponse.cs
+++ b/src/InnovateFuture.Api/Controllers/UsersController/GetUserResponse.cs
@@ -3,11 +3,10 @@ namespace InnovateFuture.Api.Controllers.UsersController;
 public class GetUserResponse
 {
     public Guid UserId { get; set; }
-    public Guid CognitoUuid { get; set; }
+    public Guid? CognitoUuid { get; set; }
     public Guid DefaultProfile { get; set; }
     public string Email { get; set; }
-    public string? GivenName { get; set; }
-    public string? FamilyName { get; set; }
+    public string? FullName { get; set; }
     public string? Phone { get; set; }
     public string? Birthday { get; set; }
 }

--- a/src/InnovateFuture.Api/Controllers/UsersController/QueryUsersRequest.cs
+++ b/src/InnovateFuture.Api/Controllers/UsersController/QueryUsersRequest.cs
@@ -8,8 +8,7 @@ public class QueryUsersRequest
     public Guid? InvitedByProfile { get; set; }
     public Guid? SupervisedByProfile { get; set; }
     public string? Email { get; set; }
-    public string? GivenName { get; set; }
-    public string? FamilyName { get; set; }
+    public string? FullName { get; set; }
     public string? Phone { get; set; }
     public DateTime? Birthday { get; set; } 
 }

--- a/src/InnovateFuture.Api/Controllers/UsersController/UpdateUserRequest.cs
+++ b/src/InnovateFuture.Api/Controllers/UsersController/UpdateUserRequest.cs
@@ -2,11 +2,10 @@ namespace InnovateFuture.Api.Controllers.UsersController;
 
 public class UpdateUserRequest
 {
-    public Guid UserId { get; set; }
+    public Guid? CognitoUuid { get; set; }
     public Guid? DefaultProfile{ get; set;}
     public string? Email { get; set; }
-    public string? GivenName { get; set; }
-    public string? FamilyName { get; set; }
+    public string? FullName { get; set; }
     public string? Phone { get; set; }
     public DateTime? Birthday { get; set; } 
 }

--- a/src/InnovateFuture.Api/Controllers/UsersController/UsersController.cs
+++ b/src/InnovateFuture.Api/Controllers/UsersController/UsersController.cs
@@ -25,29 +25,31 @@ public class UsersController : ControllerBase
     }
     
     /// <summary>
-    /// Create a new User.
+    /// Creates a new user.
     /// </summary>
-    /// <param name="request"></param>
-    /// <returns></returns>
+    /// <param name="request">The details of the user to create.</param>
+    /// <returns>A response containing the ID of the created user.</returns>
     [AllowAnonymous]
     [HttpPost]
     public async Task<IActionResult> CreateUser([FromBody] CreateUserRequest request)
     {
         var command = _mapper.Map<CreateUserCommand>(request);
         var userId = await _mediator.Send(command);
-        return Ok(new { UserId = userId });
+        return CreatedAtAction(nameof(GetUser),new{id = userId},new { UserId = userId });
     }
     
     /// <summary>
-    /// Update user details by its specified ID.
+    /// Updates user details by its specified ID.
     /// </summary>
-    /// <param name="request"></param>
-    /// <returns></returns>
+    /// <param name="id">The ID of the user to update.</param>
+    /// <param name="request">The updated user details.</param>
+    /// <returns>A response containing the ID of the updated user.</returns>
     [AllowAnonymous]
-    [HttpPut]
-    public async Task<IActionResult> UpdateUser([FromBody] UpdateUserRequest request)
+    [HttpPut("{id}")]
+    public async Task<IActionResult> UpdateUser(Guid id, [FromBody] UpdateUserRequest request)
     {
         var command = _mapper.Map<UpdateUserCommand>(request);
+        command.UserId = id;
         var userId = await _mediator.Send(command);
         return Ok(new { UserId = userId });
     }
@@ -55,8 +57,8 @@ public class UsersController : ControllerBase
     /// <summary>
     /// Retrieves a user by its specified ID.
     /// </summary>
-    /// <param name="id"></param>
-    /// <returns></returns>
+    /// <param name="id">The ID of the user to retrieve.</param>
+    /// <returns>The details of the specified user.</returns>
     [AllowAnonymous]
     [HttpGet("{id}")]
     public async Task<IActionResult> GetUser(Guid id)
@@ -66,10 +68,12 @@ public class UsersController : ControllerBase
         var userResponse =  _mapper.Map<GetUserResponse>(user);
         return Ok(userResponse);
     }
+    
     /// <summary>
-    /// Retrieves users by specified queries.
+    /// Retrieves a list of users based on specified query parameters.
     /// </summary>
-    /// <returns></returns>
+    /// <param name="queries">The query parameters to filter users.</param>
+    /// <returns>A list of users that match the query parameters.</returns>
     [AllowAnonymous]
     [HttpGet]
     public async Task<IActionResult> GetUsers([FromQuery] QueryUsersRequest queries)

--- a/src/InnovateFuture.Application/Users/Commands/CreateUser/CreateUserCommand.cs
+++ b/src/InnovateFuture.Application/Users/Commands/CreateUser/CreateUserCommand.cs
@@ -3,14 +3,12 @@ using MediatR;
 namespace InnovateFuture.Application.Users.Commands.CreateUser;
 public class CreateUserCommand : IRequest<Guid>
 {
-    public Guid CognitoUuid { get; set; }
     public Guid OrgId { get; set; }
     public Guid RoleId { get; set; }
     public Guid? InvitedBy { get; set; }
     public Guid? SupervisedBy { get; set; }
     public string Email { get; set; }
-    public string? GivenName { get; set; }
-    public string? FamilyName { get; set; }
+    public string? FullName { get; set; }
     public string? Phone { get; set; }
     public DateTime? Birthday { get; set; } 
 }

--- a/src/InnovateFuture.Application/Users/Commands/CreateUser/CreateUserHandler.cs
+++ b/src/InnovateFuture.Application/Users/Commands/CreateUser/CreateUserHandler.cs
@@ -28,15 +28,8 @@ public class CreateUserHandler : IRequestHandler<CreateUserCommand, Guid>
         
         // Create user
         var user = new User(
-            command.CognitoUuid,
-            command.Email
-            );
-        // Add other details if provided
-        user.UpdateUserDetails(
-            null,
             command.Email,
-            command.GivenName,
-            command.FamilyName,
+            command.FullName,
             command.Phone,
             command.Birthday
             );

--- a/src/InnovateFuture.Application/Users/Commands/CreateUser/CreateUserValidator.cs
+++ b/src/InnovateFuture.Application/Users/Commands/CreateUser/CreateUserValidator.cs
@@ -5,20 +5,14 @@ public class CreateUserCommandValidator : AbstractValidator<CreateUserCommand>
 {
     public CreateUserCommandValidator()
     {
-        RuleFor(x => x.CognitoUuid)
-            .NotEmpty().WithMessage("Cognito Uuid is required.");
-        RuleFor(x => x.OrgId)
-            .NotEmpty().WithMessage("Cognito Org Id is required.");
         RuleFor(x => x.RoleId)
-            .NotEmpty().WithMessage("Cognito Role Id is required.");
+            .NotEmpty().WithMessage("Role Id is required.");
         RuleFor(x => x.Email)
             .NotEmpty().WithMessage("Email is required.")
             .MaximumLength(255).WithMessage("Email must not exceed 255 characters.")
             .EmailAddress().WithMessage("Kindly enter a valid Email Address.");
-        RuleFor(x => x.GivenName)
-            .MaximumLength(100).WithMessage("GivenName must not exceed 100 characters.");
-        RuleFor(x => x.FamilyName)
-            .MaximumLength(100).WithMessage("GivenName must not exceed 100 characters.");
+        RuleFor(x => x.FullName)
+            .MaximumLength(100).WithMessage("Full name must not exceed 100 characters.");
         RuleFor(x => x.Phone)
             .Matches("^\\+61\\s4\\d{8}$").WithMessage("Kindly enter a valid AU Phone Number.");
         RuleFor(x => x.Birthday)

--- a/src/InnovateFuture.Application/Users/Commands/UpdateUser/UpdateUserCommand.cs
+++ b/src/InnovateFuture.Application/Users/Commands/UpdateUser/UpdateUserCommand.cs
@@ -5,10 +5,10 @@ namespace InnovateFuture.Application.Users.Commands.UpdateUser;
 public class UpdateUserCommand : IRequest<Guid>
 {
     public Guid UserId { get; set; }
+    public Guid? CognitoUuid { get; set; }
     public Guid? DefaultProfile{ get; set;}
     public string? Email { get; set; }
-    public string? GivenName { get; set; }
-    public string? FamilyName { get; set; }
+    public string? FullName { get; set; }
     public string? Phone { get; set; }
     public DateTime? Birthday { get; set; } 
 }

--- a/src/InnovateFuture.Application/Users/Commands/UpdateUser/UpdateUserCommandValidator.cs
+++ b/src/InnovateFuture.Application/Users/Commands/UpdateUser/UpdateUserCommandValidator.cs
@@ -10,10 +10,8 @@ public class UpdateUserCommandValidator : AbstractValidator<UpdateUserCommand>
         RuleFor(x => x.Email)
             .MaximumLength(255).WithMessage("Email must not exceed 255 characters.")
             .EmailAddress().WithMessage("Kindly enter a valid Email Address.");
-        RuleFor(x => x.GivenName)
-            .MaximumLength(100).WithMessage("GivenName must not exceed 100 characters.");
-        RuleFor(x => x.FamilyName)
-            .MaximumLength(100).WithMessage("GivenName must not exceed 100 characters.");
+        RuleFor(x => x.FullName)
+            .MaximumLength(100).WithMessage("Full name must not exceed 100 characters.");
         RuleFor(x => x.Phone)
             .Matches("^\\+61\\s4\\d{8}$").WithMessage("Kindly enter a valid AU Phone Number.");
         RuleFor(x => x.Birthday)

--- a/src/InnovateFuture.Application/Users/Commands/UpdateUser/UpdateUserHandler.cs
+++ b/src/InnovateFuture.Application/Users/Commands/UpdateUser/UpdateUserHandler.cs
@@ -18,10 +18,10 @@ public class UpdateUserHandler : IRequestHandler<UpdateUserCommand, Guid>
         
         // update
         user.UpdateUserDetails(
+            command.CognitoUuid,
             command.DefaultProfile, 
             command.Email,
-            command.GivenName, 
-            command.FamilyName,
+            command.FullName, 
             command.Phone,
             command.Birthday
             );

--- a/src/InnovateFuture.Application/Users/Queries/GetUsers/GetUsersHandler.cs
+++ b/src/InnovateFuture.Application/Users/Queries/GetUsers/GetUsersHandler.cs
@@ -26,8 +26,7 @@ public class GetUsersHandler : IRequestHandler<GetUsersQuery, IEnumerable<User>>
             queryPredicate = u =>
                 (query.CognitoUuid == null || u.CognitoUuid == query.CognitoUuid) &&
                 (string.IsNullOrEmpty(query.Email) || u.Email == query.Email) &&
-                (string.IsNullOrEmpty(query.GivenName) || u.GivenName == query.GivenName) &&
-                (string.IsNullOrEmpty(query.FamilyName) || u.FamilyName == query.FamilyName) &&
+                (string.IsNullOrEmpty(query.FullName) || u.FullName == query.FullName) &&
                 (string.IsNullOrEmpty(query.Phone) || u.Phone == query.Phone) &&
                 (!query.Birthday.HasValue || u.Birthday == query.Birthday);
         }

--- a/src/InnovateFuture.Application/Users/Queries/GetUsers/GetUsersQuery.cs
+++ b/src/InnovateFuture.Application/Users/Queries/GetUsers/GetUsersQuery.cs
@@ -7,8 +7,7 @@ public class GetUsersQuery : IRequest<IEnumerable<User>>
 {
     public Guid? CognitoUuid { get; set; }
     public string? Email { get; set; }
-    public string? GivenName { get; set; }
-    public string? FamilyName { get; set; }
+    public string? FullName { get; set; }
     public string? Phone { get; set; }
     public DateTime? Birthday { get; set; } 
 }

--- a/src/InnovateFuture.Application/Users/Queries/GetUsers/GetUsersQueryValidator.cs
+++ b/src/InnovateFuture.Application/Users/Queries/GetUsers/GetUsersQueryValidator.cs
@@ -8,10 +8,8 @@ public class GetUsersQueryValidator : AbstractValidator<GetUsersQuery>
         RuleFor(x => x.Email)
             .MaximumLength(255).WithMessage("Email must not exceed 255 characters.")
             .EmailAddress().WithMessage("Kindly enter a valid Email Address.");
-        RuleFor(x => x.GivenName)
-            .MaximumLength(100).WithMessage("GivenName must not exceed 100 characters.");
-        RuleFor(x => x.FamilyName)
-            .MaximumLength(100).WithMessage("GivenName must not exceed 100 characters.");
+        RuleFor(x => x.FullName)
+            .MaximumLength(100).WithMessage("Full name must not exceed 100 characters.");
         RuleFor(x => x.Phone)
             .Matches("^\\+61\\s4\\d{8}$").WithMessage("Kindly enter a valid AU Phone Number.");
         RuleFor(x => x.Birthday)

--- a/src/InnovateFuture.Domain/Entities/Organisation.cs
+++ b/src/InnovateFuture.Domain/Entities/Organisation.cs
@@ -6,7 +6,6 @@ public class Organisation
 {
     public Guid OrgId { get; private set; }
     public string OrgName { get; private set; }
-    // todo: to ask: ? || default value
     public string? LogoUrl { get; private set; }
     public string? WebsiteUrl { get; private set; }
     public string? Address { get; private set; }

--- a/src/InnovateFuture.Domain/Entities/Profile.cs
+++ b/src/InnovateFuture.Domain/Entities/Profile.cs
@@ -4,7 +4,7 @@ public class Profile
 {
     public Guid ProfileId { get; private set; }
     public Guid UserId { get; private set; }
-    public Guid OrgId { get; private set; }
+    public Guid? OrgId { get; private set; }
     public Guid RoleId { get; private set; }
     public Boolean IsActive { get; private set; }
     public string? Email { get; private set; }
@@ -17,7 +17,7 @@ public class Profile
     // navigation properties
     public User User { get; private set; }
     public Role Role { get; private set; }
-    public Organisation Organisation { get; private set; }
+    public Organisation? Organisation { get; private set; }
     public Profile? InvitedByProfile { get; private set; }
     public Profile? SupervisedByProfile { get; private set; }
     public DateTime CreatedAt { get; private set; }
@@ -26,7 +26,7 @@ public class Profile
     public Profile(
         User user, 
         Role role, 
-        Organisation organisation, 
+        Organisation? organisation, 
         Profile? invitedByProfile, 
         Profile? supervisedByProfile
         )
@@ -37,7 +37,7 @@ public class Profile
         Role = role;
         RoleId = role.RoleId;
         Organisation = organisation;
-        OrgId = Organisation.OrgId;
+        OrgId = Organisation?.OrgId;
         InvitedByProfile = invitedByProfile;
         SupervisedByProfile = supervisedByProfile;
         InvitedBy = invitedByProfile?.ProfileId;

--- a/src/InnovateFuture.Domain/Entities/User.cs
+++ b/src/InnovateFuture.Domain/Entities/User.cs
@@ -4,22 +4,23 @@ namespace InnovateFuture.Domain.Entities;
 public class User
 {
     public Guid UserId { get; private set; }
-    public Guid CognitoUuid { get; private set; }
     public string Email { get; private set; }
+    public Guid? CognitoUuid { get; private set; }
     public Guid? DefaultProfile { get; private set; }
-    public string? GivenName { get; private set; }
-    public string? FamilyName { get; private set; }
+    public string? FullName { get; private set; }
     public string? Phone { get; private set; }
     public DateTime? Birthday { get; private set; }
     // navigation properties
     public ICollection<Profile>? Profiles { get; private set; } = new List<Profile>();
     public DateTime CreatedAt { get; private set; }
     public DateTime UpdatedAt { get; private set; }
-    public User(Guid cognitoUuid, string email)
+    public User(string email,string? fullName, string? phone, DateTime? birthday)
     {
         UserId = Guid.NewGuid();
-        CognitoUuid = cognitoUuid;
         Email = email;
+        FullName = fullName;
+        Phone = phone;
+        Birthday = birthday;
         CreatedAt = DateTime.UtcNow;
         UpdatedAt = DateTime.UtcNow;
     }
@@ -28,12 +29,13 @@ public class User
         DefaultProfile = updatedDefaultProfile;
         UpdatedAt = DateTime.UtcNow;
     }
-    public void UpdateUserDetails(Guid? updatedDefaultProfile, string? email, string? givenName, string? familyName,  string? phone, DateTime? birthday)
+    
+    public void UpdateUserDetails(Guid? updatedDefaultProfile, Guid? cognitoUuid, string? email, string? fullName, string? phone, DateTime? birthday)
     {
+        CognitoUuid = cognitoUuid??CognitoUuid;
         DefaultProfile = updatedDefaultProfile??DefaultProfile;
         Email = string.IsNullOrWhiteSpace(email)?Email:email;
-        GivenName = string.IsNullOrWhiteSpace(givenName)?GivenName:givenName;
-        FamilyName =  string.IsNullOrWhiteSpace(familyName)?FamilyName:familyName;
+        FullName = string.IsNullOrWhiteSpace(fullName)?fullName:FullName;
         Phone = string.IsNullOrWhiteSpace(phone)?Phone:phone;
         Birthday = birthday??Birthday;
         UpdatedAt = DateTime.UtcNow;

--- a/src/InnovateFuture.Infrastructure/Migrations/20250103120027_MakeOrgIdNullableInProfile.Designer.cs
+++ b/src/InnovateFuture.Infrastructure/Migrations/20250103120027_MakeOrgIdNullableInProfile.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using InnovateFuture.Infrastructure.Common.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace InnovateFuture.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250103120027_MakeOrgIdNullableInProfile")]
+    partial class MakeOrgIdNullableInProfile
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -210,6 +213,7 @@ namespace InnovateFuture.Infrastructure.Migrations
                         .HasColumnName("birthday");
 
                     b.Property<Guid?>("CognitoUuid")
+                        .IsRequired()
                         .HasColumnType("uuid")
                         .HasColumnName("cognito_uuid");
 
@@ -227,10 +231,15 @@ namespace InnovateFuture.Infrastructure.Migrations
                         .HasColumnType("character varying(255)")
                         .HasColumnName("email");
 
-                    b.Property<string>("FullName")
+                    b.Property<string>("FamilyName")
                         .HasMaxLength(100)
                         .HasColumnType("character varying(100)")
-                        .HasColumnName("full_name");
+                        .HasColumnName("family_name");
+
+                    b.Property<string>("GivenName")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)")
+                        .HasColumnName("given_name");
 
                     b.Property<string>("Phone")
                         .HasMaxLength(50)

--- a/src/InnovateFuture.Infrastructure/Migrations/20250103120027_MakeOrgIdNullableInProfile.cs
+++ b/src/InnovateFuture.Infrastructure/Migrations/20250103120027_MakeOrgIdNullableInProfile.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace InnovateFuture.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakeOrgIdNullableInProfile : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<Guid>(
+                name: "org_id",
+                table: "Profiles",
+                type: "uuid",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<Guid>(
+                name: "org_id",
+                table: "Profiles",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldNullable: true);
+        }
+    }
+}

--- a/src/InnovateFuture.Infrastructure/Migrations/20250103132053_MakeCognitoUuidNullable.Designer.cs
+++ b/src/InnovateFuture.Infrastructure/Migrations/20250103132053_MakeCognitoUuidNullable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using InnovateFuture.Infrastructure.Common.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace InnovateFuture.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250103132053_MakeCognitoUuidNullable")]
+    partial class MakeCognitoUuidNullable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -227,10 +230,15 @@ namespace InnovateFuture.Infrastructure.Migrations
                         .HasColumnType("character varying(255)")
                         .HasColumnName("email");
 
-                    b.Property<string>("FullName")
+                    b.Property<string>("FamilyName")
                         .HasMaxLength(100)
                         .HasColumnType("character varying(100)")
-                        .HasColumnName("full_name");
+                        .HasColumnName("family_name");
+
+                    b.Property<string>("GivenName")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)")
+                        .HasColumnName("given_name");
 
                     b.Property<string>("Phone")
                         .HasMaxLength(50)

--- a/src/InnovateFuture.Infrastructure/Migrations/20250103132053_MakeCognitoUuidNullable.cs
+++ b/src/InnovateFuture.Infrastructure/Migrations/20250103132053_MakeCognitoUuidNullable.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace InnovateFuture.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakeCognitoUuidNullable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<Guid>(
+                name: "cognito_uuid",
+                table: "Users",
+                type: "uuid",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<Guid>(
+                name: "cognito_uuid",
+                table: "Users",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldNullable: true);
+        }
+    }
+}

--- a/src/InnovateFuture.Infrastructure/Migrations/20250104003011_UpdateUsersFullName.Designer.cs
+++ b/src/InnovateFuture.Infrastructure/Migrations/20250104003011_UpdateUsersFullName.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using InnovateFuture.Infrastructure.Common.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace InnovateFuture.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250104003011_UpdateUsersFullName")]
+    partial class UpdateUsersFullName
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/InnovateFuture.Infrastructure/Migrations/20250104003011_UpdateUsersFullName.cs
+++ b/src/InnovateFuture.Infrastructure/Migrations/20250104003011_UpdateUsersFullName.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace InnovateFuture.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdateUsersFullName : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "family_name",
+                table: "Users");
+
+            migrationBuilder.RenameColumn(
+                name: "given_name",
+                table: "Users",
+                newName: "full_name");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "full_name",
+                table: "Users",
+                newName: "given_name");
+
+            migrationBuilder.AddColumn<string>(
+                name: "family_name",
+                table: "Users",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true);
+        }
+    }
+}

--- a/src/InnovateFuture.Infrastructure/Profiles/Persistence/ModelConfigs/ProfileConfig.cs
+++ b/src/InnovateFuture.Infrastructure/Profiles/Persistence/ModelConfigs/ProfileConfig.cs
@@ -18,8 +18,8 @@ public class ProfileConfig : IEntityTypeConfiguration<Profile>
         // Column Mappings
         builder.Property(p => p.ProfileId).HasColumnType("uuid").HasColumnName("profile_id").IsRequired();
         builder.Property(p => p.UserId).HasColumnType("uuid").HasColumnName("user_id").IsRequired();
-        builder.Property(p => p.OrgId).HasColumnType("uuid").HasColumnName("org_id").IsRequired();
         builder.Property(p => p.RoleId).HasColumnType("uuid").HasColumnName("role_id").IsRequired();
+        builder.Property(p => p.OrgId).HasColumnType("uuid").HasColumnName("org_id"); // no need for platform admin
         builder.Property(p => p.InvitedBy).HasColumnType("uuid").HasColumnName("invited_by");
         builder.Property(p => p.SupervisedBy).HasColumnType("uuid").HasColumnName("supervised_by");
         builder.Property(p => p.Name).HasColumnName("name").HasMaxLength(100);

--- a/src/InnovateFuture.Infrastructure/Users/Persistence/ModelConfigs/UserConfig.cs
+++ b/src/InnovateFuture.Infrastructure/Users/Persistence/ModelConfigs/UserConfig.cs
@@ -23,10 +23,9 @@ public class UserConfig : IEntityTypeConfiguration<User>
         
         // Column Mappings
         builder.Property(u => u.UserId).HasColumnType("uuid").HasColumnName("user_id").IsRequired();
-        builder.Property(u => u.CognitoUuid).HasColumnType("uuid").HasColumnName("cognito_uuid").IsRequired();
+        builder.Property(u => u.CognitoUuid).HasColumnType("uuid").HasColumnName("cognito_uuid");
         builder.Property(u => u.DefaultProfile).HasColumnType("uuid").HasColumnName("default_profile");
-        builder.Property(u => u.GivenName).HasColumnName("given_name").HasMaxLength(100);
-        builder.Property(u => u.FamilyName).HasColumnName("family_name").HasMaxLength(100);
+        builder.Property(u => u.FullName).HasColumnName("full_name").HasMaxLength(100);
         builder.Property(u => u.Email).HasColumnName("email").HasMaxLength(255).IsRequired();
         builder.Property(u => u.Phone).HasColumnName("phone").HasMaxLength(50);
         builder.Property(u => u.Birthday).HasColumnType("date").HasColumnName("birthday");

--- a/tests/InnovateFuture.Application.Tests/Users/CreateUserHandlerTest.cs
+++ b/tests/InnovateFuture.Application.Tests/Users/CreateUserHandlerTest.cs
@@ -21,7 +21,6 @@ public class CreateUserHandlerTest
         var handler = new CreateUserHandler(mockedUserRepository.Object, mockedRoleRepository.Object, mockedOrgRepository.Object,mockedProfileRepository.Object);
         var command = new CreateUserCommand
         {
-            CognitoUuid = Guid.NewGuid(),
             Email = "test@example.com",
             RoleId = Guid.NewGuid(),
             OrgId = Guid.NewGuid(),
@@ -42,7 +41,6 @@ public class CreateUserHandlerTest
         mockedOrgRepository.Verify(o => o.GetByIdAsync(command.OrgId), Times.Once);
         
         mockedUserRepository.Verify(u => u.AddAsync(It.Is<User>(user =>
-            user.CognitoUuid == command.CognitoUuid &&
             user.Email == command.Email &&
             user.Profiles.Count == 1 &&
             user.Profiles.First().UserId == user.UserId &&

--- a/tests/InnovateFuture.Application.Tests/Users/GetUsersHandlerTest.cs
+++ b/tests/InnovateFuture.Application.Tests/Users/GetUsersHandlerTest.cs
@@ -24,8 +24,8 @@ public class GetUsersHandlerTest
         var query = new GetUsersQuery();
         var expectedUsers = new List<User>
         {
-            new User (Guid.NewGuid(),"test1@example.com" ),
-            new User (Guid.NewGuid(),"test2@example.com" ),
+            new User ("test1@example.com",null,null,null ),
+            new User ("test2@example.com",null,null,null ),
         };
 
         _mockedUserRepository
@@ -55,29 +55,26 @@ public class GetUsersHandlerTest
 
         // Assert
         _mockedUserRepository.Verify(repo => repo.GetAnyAsync(It.Is<Expression<Func<User, bool>>>(predicate =>
-            predicate.Compile().Invoke(new User (Guid.NewGuid(),"test@example.com" )
+            predicate.Compile().Invoke(new User ("test@example.com",null,null,null )
                ) &&
-            !predicate.Compile().Invoke( new User (Guid.NewGuid(),"other@example.com" ))
+            !predicate.Compile().Invoke( new User ("other@example.com" ,null,null,null))
         )), Times.Once);
     }
     
     [Fact]
-    public async Task Handle_ShouldFilterUsersByGivenNameNFamilyName_WhenMultipleMixedConditionsProvided()
+    public async Task Handle_ShouldFilterUsersByFullName_WhenMultipleMixedConditionsProvided()
     {
         // Arrange
         var query = new GetUsersQuery
         {
             Email = "test@example.com",
-            GivenName = "John",
-            FamilyName = "Doe"
+            FullName = "John Doe"
         };
         
         var correctUser = new User
-            (Guid.NewGuid(),"test@example.com");
-        correctUser.UpdateUserDetails(null,null,"John","Doe",null,null);
+            ("test@example.com","John Doe",null,null);
         var wrongUser = new User
-            (Guid.NewGuid(),"wrong@example.com");
-        wrongUser.UpdateUserDetails(null,null,"Mary","Green",null,null);
+            ("wrong@example.com","Mary Green",null,null);
 
         _mockedUserRepository
             .Setup(repo => repo.GetAnyAsync(It.IsAny<Expression<Func<User, bool>>>()))


### PR DESCRIPTION
This PR introduces the following database schema changes:

Users Table:

- Made the CognitoUuid column nullable to support scenarios where users may not have an associated Cognito identity.
- Merge given name and family name into full name.

Profile Table:

- Made the OrgId column nullable to allow profiles without an associated organization.

Testing Method:

- Check pdAdmin and swagger create user api

	
	
Related Ticket

[JIRA Ticket: IF-83](https://dext.atlassian.net/jira/software/c/projects/IF/boards/26?selectedIssue=IF-83)
