### PR TITLE
feat: update Jenkins VM startup script to use templatefile for Docker…

### DIFF
--- a/.devops/dev/tf-jenkins/terraform-gcp-jenkins.tf
+++ b/.devops/dev/tf-jenkins/terraform-gcp-jenkins.tf
@@ -68,7 +68,9 @@ resource "google_compute_instance" "jenkins_vm" {
     ssh-keys = var.my_ssh_key
   }
 
-  metadata_startup_script = file("startup.sh")
+  metadata_startup_script = templatefile("startup.sh", {
+    docker_host = "tcp://localhost:2375"
+  })
 
   scheduling {
     preemptible       = false


### PR DESCRIPTION

This pull request includes an update to the Terraform configuration for the Jenkins VM instance. The most important change involves modifying the way the startup script is handled to include a Docker host configuration.

Configuration updates:

* [`.devops/dev/tf-jenkins/terraform-gcp-jenkins.tf`](diffhunk://#diff-177f2786ea4fbc58d4e6912a839a58ee0d3ec3cd401616ccc0937d6fe818e361L71-R73): Changed the `metadata_startup_script` from using `file("startup.sh")` to `templatefile("startup.sh", { docker_host = "tcp://localhost:2375" })` to include Docker host configuration.