### PR TITLE
remove redundent connectionString declaration

### DIFF
--- a/src/InnovateFuture.Api/Program.cs
+++ b/src/InnovateFuture.Api/Program.cs
@@ -95,7 +95,6 @@ namespace InnovateFuture.Api
             #region DB connection
             builder.Services.Configure<DBConnectionConfig>(builder.Configuration);
 
-            var connectionString = builder.Configuration["DBConnection"];
             Console.WriteLine($"Connection string: {connectionString}");
             
             builder.Services.AddDbContext<ApplicationDbContext>(


### PR DESCRIPTION
This pull request includes a small change to the `src/InnovateFuture.Api/Program.cs` file. The change removes the `connectionString` variable assignment from the `Main` method.

* [`src/InnovateFuture.Api/Program.cs`](diffhunk://#diff-7240d3be43350a8d8a8b1b7d715f71a81998d53cc487f824e9dacd281c47d20eL98): Removed the assignment of the `connectionString` variable from the `Main` method.