### PR TITLE
feat: add test container in docker compose and add nobuild flag

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,13 @@
 *.suo
 *.user
 *.sln.docstates
+
+# Ignore Git-related files
+.git
+.gitignore
+
+# Ignore log files
+**/*.log
+
+# Ignore any temporary files
+**/tmp/

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,5 +1,5 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0
-WORKDIR /src
+FROM mcr.microsoft.com/dotnet/sdk:8.0 as build
+WORKDIR /
 
 # Install dotnet-ef tool and setup env path
 RUN dotnet tool install --global dotnet-ef --version 9.0.0
@@ -7,15 +7,20 @@ ENV PATH="$PATH:/root/.dotnet/tools"
 
 # Copy solution, project files and restore dependencies
 COPY ["InnovateFuture.sln", "../"]
-COPY ["src/InnovateFuture.Api/*.csproj", "InnovateFuture.Api/"]
-COPY ["src/InnovateFuture.Application/*.csproj", "InnovateFuture.Application/"]
-COPY ["src/InnovateFuture.Domain/*.csproj", "InnovateFuture.Domain/"]
-COPY ["src/InnovateFuture.Infrastructure/*.csproj", "InnovateFuture.Infrastructure/"]
-
-RUN dotnet restore "InnovateFuture.Api/InnovateFuture.Api.csproj"
+COPY ["src/InnovateFuture.Api/*.csproj", "src/InnovateFuture.Api/"]
+COPY ["src/InnovateFuture.Application/*.csproj", "src/InnovateFuture.Application/"]
+COPY ["src/InnovateFuture.Domain/*.csproj", "src/InnovateFuture.Domain/"]
+COPY ["src/InnovateFuture.Infrastructure/*.csproj", "src/InnovateFuture.Infrastructure/"]
+COPY ["tests/InnovateFuture.Api.Tests/*.csproj", "tests/InnovateFuture.Api.Tests/"]
+COPY ["tests/InnovateFuture.Application.Tests/*.csproj", "tests/InnovateFuture.Application.Tests/"]
+COPY ["tests/InnovateFuture.Domain.Tests/*.csproj", "tests/InnovateFuture.Domain.Tests/"]
+RUN dotnet restore
 
 # Copy all source code to allow builds
-COPY src/ .
+COPY src/ src/
+RUN ls src/*
+COPY tests/ tests/
+RUN ls tests/*
 
 # Build the entire project (to make DLLs available for following)
-RUN dotnet build "InnovateFuture.Api/InnovateFuture.Api.csproj" -c Release
+RUN dotnet build "InnovateFuture.sln" -c Release

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,5 +1,17 @@
-FROM inff-api-build
+FROM inff-api-build AS publish
+WORKDIR /src
+# Publish the application for production
+RUN dotnet publish "InnovateFuture.Api/InnovateFuture.Api.csproj" \
+  -c Release -o /app/publish \
+  --no-restore --no-build
 
-WORKDIR /
-COPY ./tests .
-ENTRYPOINT ["dotnet", "test", "--no-build"]
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+WORKDIR /app
+# Copy published output from the publish stage
+COPY --from=publish /app/publish .
+
+ENV ASPNETCORE_URLS=http://+:5091/
+ENV ASPNETCORE_ENVIRONMENT=Development
+
+EXPOSE 5091
+ENTRYPOINT ["dotnet", "InnovateFuture.Api.dll"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,15 +19,31 @@ services:
     depends_on:
       migration:
         condition: service_completed_successfully
+      test:
+        condition: service_completed_successfully
     networks:
       - app-network
+
+  test:
+    image: inff-api-build
+    command: >
+      sh -c "dotnet test
+      --configuration Release
+      --no-build --verbosity normal"
+    depends_on:
+      base:
+        condition: service_completed_successfully
+      migration:
+        condition: service_completed_successfully
 
   migration:
     image: inff-api-build
     command: >
       sh -c "dotnet ef database update
-      --project InnovateFuture.Infrastructure/InnovateFuture.Infrastructure.csproj
-      --startup-project InnovateFuture.Api/InnovateFuture.Api.csproj"
+      --project src/InnovateFuture.Infrastructure/InnovateFuture.Infrastructure.csproj
+      --startup-project src/InnovateFuture.Api/InnovateFuture.Api.csproj
+      --configuration Release
+      --no-build"
     environment:
       - DBConnection=Host=${DB_HOST};Port=${DB_PORT};Database=${DB_NAME};Username=${DB_USER};Password=${DB_PASS};
       - JWTConfig__SecretKey=${JWT_SECRET}


### PR DESCRIPTION
# Summary
Containerised dotnet test and include it into the docker-compose file, also add no-build and configuration flag to migration service to speed up docker-compose.
## Current container dependencies
### Api Service
- **migration**
  - condition: on success
- **test**
  - condition: on success
### Test Service
- **base**
  - condition: on success
- **migration**
  - condition: on success