### PR TITLE
Add Discord PR notification workflow

### DIFF
--- a/.github/workflows/pr-discord-notification.yml
+++ b/.github/workflows/pr-discord-notification.yml
@@ -11,20 +11,34 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Discord PR Notification
+      - name: Create PR notification
         if: github.event.pull_request.draft == false
         uses: tsickert/discord-webhook@v6.0.0
         with:
           webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
           thread-id: "1330422313769893938"
-          content: ${{ github.event.action == 'opened' && '🆕 New PR:' || '🔄 PR Updated:' }} ${{ github.event.pull_request.html_url }}
+          content: ""  # Empty content, using embed instead
+          embed-title: ${{ github.event.action == 'opened' && '🆕 New Pull Request' || '🔄 Pull Request Updated' }}
+          embed-description: ${{ github.event.pull_request.title }}
+          embed-url: ${{ github.event.pull_request.html_url }}
+          embed-color: ${{ github.event.action == 'opened' && '5763719' || '15844367' }}
+          embed-author-name: ${{ github.event.pull_request.user.login }}
+          embed-author-url: ${{ github.event.pull_request.user.html_url }}
+          embed-author-icon-url: ${{ github.event.pull_request.user.avatar_url }}
           wait: true
 
-      - name: Discord PR Merged Notification
+      - name: Create PR merged notification
         if: github.event.pull_request.merged == true && github.event.pull_request.draft == false
         uses: tsickert/discord-webhook@v6.0.0
         with:
           webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
           thread-id: "1330422313769893938"
-          content: 🎉 PR Merged: ${{ github.event.pull_request.html_url }}
+          content: ""  # Empty content, using embed instead
+          embed-title: "🎉 Pull Request Merged"
+          embed-description: ${{ github.event.pull_request.title }}
+          embed-url: ${{ github.event.pull_request.html_url }}
+          embed-color: "3066993"  # Green color
+          embed-author-name: ${{ github.event.pull_request.merged_by.login }}
+          embed-author-url: ${{ github.event.pull_request.merged_by.html_url }}
+          embed-author-icon-url: ${{ github.event.pull_request.merged_by.avatar_url }}
           wait: true

--- a/.github/workflows/pr-discord-notification.yml
+++ b/.github/workflows/pr-discord-notification.yml
@@ -1,0 +1,31 @@
+name: PR Discord Notification
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: discord-notification-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: Discord PR Notification
+        if: github.event.pull_request.draft == false
+        continue-on-error: true
+        uses: tsickert/discord-webhook@v5.3.0
+        with:
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
+          thread-id: 1330422313769893938
+          content: |
+            ${{ github.event.action == 'opened' && '🆕 New PR:' || '🔄 PR Updated:' }} ${{ github.event.pull_request.html_url }}
+
+      - name: Discord PR Merged Notification
+        if: github.event.pull_request.merged == true && github.event.pull_request.draft == false
+        uses: tsickert/discord-webhook@v5.3.0
+        with:
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
+          thread-id: 1330422313769893938
+          content: |
+            🎉 PR Merged: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/pr-discord-notification.yml
+++ b/.github/workflows/pr-discord-notification.yml
@@ -16,7 +16,7 @@ jobs:
         continue-on-error: true
         uses: Ilshidur/action-discord@master
         env:
-          DISCORD_WEBHOOK: '${{ secrets.DISCORD_WEBHOOK }}?thread_id="1330422313769893938"'
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}?thread_id=1330422313769893938&wait=true
         with:
           args: |
             ${{ github.event.action == 'opened' && '🆕 New PR:' || '🔄 PR Updated:' }} ${{ github.event.pull_request.html_url }}
@@ -25,7 +25,7 @@ jobs:
         if: github.event.pull_request.merged == true && github.event.pull_request.draft == false
         uses: Ilshidur/action-discord@master
         env:
-          DISCORD_WEBHOOK: '${{ secrets.DISCORD_WEBHOOK }}?thread_id="1330422313769893938"'
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}?thread_id=1330422313769893938&wait=true
         with:
           args: |
             🎉 PR Merged: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/pr-discord-notification.yml
+++ b/.github/workflows/pr-discord-notification.yml
@@ -14,20 +14,18 @@ jobs:
       - name: Discord PR Notification
         if: github.event.pull_request.draft == false
         continue-on-error: true
-        run: |
-          curl -X POST "${{ secrets.DISCORD_WEBHOOK }}" \
-            -H "Content-Type: application/json" \
-            -d '{
-              "content": "${{ github.event.action == '\''opened'\'' && ''🆕 New PR:'' || ''🔄 PR Updated:'' }} ${{ github.event.pull_request.html_url }}",
-              "thread_id": "1330422313769893938"
-            }'
+        uses: Ilshidur/action-discord@master
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}?thread_id=1330422313769893938
+        with:
+          args: |
+            ${{ github.event.action == 'opened' && '🆕 New PR:' || '🔄 PR Updated:' }} ${{ github.event.pull_request.html_url }}
 
       - name: Discord PR Merged Notification
         if: github.event.pull_request.merged == true && github.event.pull_request.draft == false
-        run: |
-          curl -X POST "${{ secrets.DISCORD_WEBHOOK }}" \
-            -H "Content-Type: application/json" \
-            -d '{
-              "content": "🎉 PR Merged: ${{ github.event.pull_request.html_url }}",
-              "thread_id": "1330422313769893938"
-            }'
+        uses: Ilshidur/action-discord@master
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}?thread_id=1330422313769893938
+        with:
+          args: |
+            🎉 PR Merged: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/pr-discord-notification.yml
+++ b/.github/workflows/pr-discord-notification.yml
@@ -14,18 +14,18 @@ jobs:
       - name: Discord PR Notification
         if: github.event.pull_request.draft == false
         continue-on-error: true
-        uses: sarisia/actions-status-discord@v1
+        uses: hugoalh/send-discord-webhook-ghaction@v6.0.0
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
-          thread_id: 1330422313769893938
+          thread: 1330422313769893938
           content: |
             ${{ github.event.action == 'opened' && '🆕 New PR:' || '🔄 PR Updated:' }} ${{ github.event.pull_request.html_url }}
 
       - name: Discord PR Merged Notification
         if: github.event.pull_request.merged == true && github.event.pull_request.draft == false
-        uses: sarisia/actions-status-discord@v1
+        uses: hugoalh/send-discord-webhook-ghaction@v6.0.0
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
-          thread_id: 1330422313769893938
+          thread: 1330422313769893938
           content: |
             🎉 PR Merged: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/pr-discord-notification.yml
+++ b/.github/workflows/pr-discord-notification.yml
@@ -16,7 +16,7 @@ jobs:
         continue-on-error: true
         uses: Ilshidur/action-discord@master
         env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}?thread_id=1330422313769893938&wait=true
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}?thread_id=1330422313769893938
         with:
           args: |
             ${{ github.event.action == 'opened' && '🆕 New PR:' || '🔄 PR Updated:' }} ${{ github.event.pull_request.html_url }}
@@ -25,7 +25,7 @@ jobs:
         if: github.event.pull_request.merged == true && github.event.pull_request.draft == false
         uses: Ilshidur/action-discord@master
         env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}?thread_id=1330422313769893938&wait=true
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}?thread_id=1330422313769893938
         with:
           args: |
             🎉 PR Merged: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/pr-discord-notification.yml
+++ b/.github/workflows/pr-discord-notification.yml
@@ -7,20 +7,24 @@ on:
 
 jobs:
   notify:
-    if: ${{ !github.event.pull_request.draft }}  # Move draft check to job level
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
+
       - name: Discord PR Notification
+        if: github.event.pull_request.draft == false
         uses: tsickert/discord-webhook@v6.0.0
         with:
           webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
           thread-id: "1330422313769893938"
           content: ${{ github.event.action == 'opened' && '🆕 New PR:' || '🔄 PR Updated:' }} ${{ github.event.pull_request.html_url }}
+          wait: true
 
       - name: Discord PR Merged Notification
-        if: github.event.pull_request.merged == true
+        if: github.event.pull_request.merged == true && github.event.pull_request.draft == false
         uses: tsickert/discord-webhook@v6.0.0
         with:
           webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
           thread-id: "1330422313769893938"
           content: 🎉 PR Merged: ${{ github.event.pull_request.html_url }}
+          wait: true

--- a/.github/workflows/pr-discord-notification.yml
+++ b/.github/workflows/pr-discord-notification.yml
@@ -1,22 +1,11 @@
 name: PR Discord Notification
 
-on:
-  pull_request_target:
-    types: [opened, reopened, synchronize, closed]
+on: pull_request
 
 jobs:
   notify:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
     steps:
-      - name: Debug Event
-        run: |
-          echo "Event name: ${{ github.event_name }}"
-          echo "Action: ${{ github.event.action }}"
-          echo "PR state: ${{ github.event.pull_request.state }}"
-          echo "Is draft: ${{ github.event.pull_request.draft }}"
-
       - name: Discord PR Notification
         if: github.event.pull_request.draft == false
         uses: tsickert/discord-webhook@v6.0.0

--- a/.github/workflows/pr-discord-notification.yml
+++ b/.github/workflows/pr-discord-notification.yml
@@ -14,44 +14,20 @@ jobs:
       - name: Discord PR Notification
         if: github.event.pull_request.draft == false
         continue-on-error: true
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const webhook = process.env.DISCORD_WEBHOOK;
-            const threadId = '1330422313769893938';
-            const message = `${{ github.event.action == 'opened' && '🆕 New PR:' || '🔄 PR Updated:' }} ${{ github.event.pull_request.html_url }}`;
-
-            await fetch(`${webhook}/messages`, {
-              method: 'POST',
-              headers: {
-                'Content-Type': 'application/json',
-              },
-              body: JSON.stringify({
-                content: message,
-                thread_id: threadId
-              })
-            });
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        run: |
+          curl -X POST "${{ secrets.DISCORD_WEBHOOK }}" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "content": "${{ github.event.action == '\''opened'\'' && ''🆕 New PR:'' || ''🔄 PR Updated:'' }} ${{ github.event.pull_request.html_url }}",
+              "thread_id": "1330422313769893938"
+            }'
 
       - name: Discord PR Merged Notification
         if: github.event.pull_request.merged == true && github.event.pull_request.draft == false
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const webhook = process.env.DISCORD_WEBHOOK;
-            const threadId = '1330422313769893938';
-            const message = `🎉 PR Merged: ${{ github.event.pull_request.html_url }}`;
-
-            await fetch(`${webhook}/messages`, {
-              method: 'POST',
-              headers: {
-                'Content-Type': 'application/json',
-              },
-              body: JSON.stringify({
-                content: message,
-                thread_id: threadId
-              })
-            });
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        run: |
+          curl -X POST "${{ secrets.DISCORD_WEBHOOK }}" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "content": "🎉 PR Merged: ${{ github.event.pull_request.html_url }}",
+              "thread_id": "1330422313769893938"
+            }'

--- a/.github/workflows/pr-discord-notification.yml
+++ b/.github/workflows/pr-discord-notification.yml
@@ -7,13 +7,9 @@ on:
 jobs:
   notify:
     runs-on: ubuntu-latest
-    concurrency:
-      group: discord-notification-${{ github.ref }}
-      cancel-in-progress: true
     steps:
       - name: Discord PR Notification
         if: github.event.pull_request.draft == false
-        continue-on-error: true
         uses: tsickert/discord-webhook@v6.0.0
         with:
           webhook-url: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/pr-discord-notification.yml
+++ b/.github/workflows/pr-discord-notification.yml
@@ -19,9 +19,10 @@ jobs:
           thread-id: "1330422313769893938"
           username: "PR Bot"
           avatar-url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
-          content: "🔄 PR Updated: ${{ github.event.pull_request.html_url }}"
-          embed-title: "Success: PR Discord Notification"
-          embed-color: "5793E6"
+          content: |
+            ${{ github.event.action == 'opened' && '🆕 New PR:' || '🔄 PR Updated:' }} ${{ github.event.pull_request.html_url }}
+            **Title:** ${{ github.event.pull_request.title }}
+            **Author:** ${{ github.event.pull_request.user.login }}
 
       - name: Create PR merged notification
         if: github.event.pull_request.merged == true && github.event.pull_request.draft == false
@@ -31,6 +32,7 @@ jobs:
           thread-id: "1330422313769893938"
           username: "PR Bot"
           avatar-url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
-          content: "🎉 PR Merged: ${{ github.event.pull_request.html_url }}"
-          embed-title: "Success: PR Discord Notification"
-          embed-color: "3BA55D"
+          content: |
+            🎉 PR Merged: ${{ github.event.pull_request.html_url }}
+            **Title:** ${{ github.event.pull_request.title }}
+            **Merged by:** ${{ github.event.pull_request.merged_by.login }}

--- a/.github/workflows/pr-discord-notification.yml
+++ b/.github/workflows/pr-discord-notification.yml
@@ -1,13 +1,16 @@
 name: PR Discord Notification
 
-on: pull_request
+on:
+  workflow_dispatch:  # Allow manual trigger for testing
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
 
 jobs:
   notify:
+    if: ${{ !github.event.pull_request.draft }}  # Move draft check to job level
     runs-on: ubuntu-latest
     steps:
       - name: Discord PR Notification
-        if: github.event.pull_request.draft == false
         uses: tsickert/discord-webhook@v6.0.0
         with:
           webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
@@ -15,7 +18,7 @@ jobs:
           content: ${{ github.event.action == 'opened' && '🆕 New PR:' || '🔄 PR Updated:' }} ${{ github.event.pull_request.html_url }}
 
       - name: Discord PR Merged Notification
-        if: github.event.pull_request.merged == true && github.event.pull_request.draft == false
+        if: github.event.pull_request.merged == true
         uses: tsickert/discord-webhook@v6.0.0
         with:
           webhook-url: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/pr-discord-notification.yml
+++ b/.github/workflows/pr-discord-notification.yml
@@ -17,26 +17,11 @@ jobs:
         with:
           webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
           thread-id: "1330422313769893938"
-          content: ""
-          embed-title: ${{ github.event.pull_request.title }}
-          embed-description: |
-            **Repository**
-            ${{ github.repository }}
-
-            **Ref**
-            refs/pull/${{ github.event.pull_request.number }}/merge
-
-            **Event** - pull_request
-            #${{ github.event.pull_request.number }} ${{ github.event.pull_request.title }}
-
-            **Triggered by**
-            ${{ github.event.pull_request.user.login }}
-
-            **Workflow**
-            PR Discord Notification
-          embed-url: ${{ github.event.pull_request.html_url }}
+          username: "PR Bot"
+          avatar-url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
+          content: "🔄 PR Updated: ${{ github.event.pull_request.html_url }}"
+          embed-title: "Success: PR Discord Notification"
           embed-color: "5793E6"
-          wait: true
 
       - name: Create PR merged notification
         if: github.event.pull_request.merged == true && github.event.pull_request.draft == false
@@ -44,23 +29,8 @@ jobs:
         with:
           webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
           thread-id: "1330422313769893938"
-          content: ""
+          username: "PR Bot"
+          avatar-url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
+          content: "🎉 PR Merged: ${{ github.event.pull_request.html_url }}"
           embed-title: "Success: PR Discord Notification"
-          embed-description: |
-            **Repository**
-            ${{ github.repository }}
-
-            **Ref**
-            refs/pull/${{ github.event.pull_request.number }}/merge
-
-            **Event** - pull_request
-            #${{ github.event.pull_request.number }} ${{ github.event.pull_request.title }}
-
-            **Triggered by**
-            ${{ github.event.pull_request.merged_by.login }}
-
-            **Workflow**
-            PR Discord Notification
-          embed-url: ${{ github.event.pull_request.html_url }}
           embed-color: "3BA55D"
-          wait: true

--- a/.github/workflows/pr-discord-notification.yml
+++ b/.github/workflows/pr-discord-notification.yml
@@ -14,18 +14,18 @@ jobs:
       - name: Discord PR Notification
         if: github.event.pull_request.draft == false
         continue-on-error: true
-        uses: Ilshidur/action-discord@master
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}?thread_id=1330422313769893938
+        uses: sarisia/actions-status-discord@v1
         with:
-          args: |
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          thread_id: 1330422313769893938
+          content: |
             ${{ github.event.action == 'opened' && '🆕 New PR:' || '🔄 PR Updated:' }} ${{ github.event.pull_request.html_url }}
 
       - name: Discord PR Merged Notification
         if: github.event.pull_request.merged == true && github.event.pull_request.draft == false
-        uses: Ilshidur/action-discord@master
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}?thread_id=1330422313769893938
+        uses: sarisia/actions-status-discord@v1
         with:
-          args: |
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          thread_id: 1330422313769893938
+          content: |
             🎉 PR Merged: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/pr-discord-notification.yml
+++ b/.github/workflows/pr-discord-notification.yml
@@ -14,18 +14,18 @@ jobs:
       - name: Discord PR Notification
         if: github.event.pull_request.draft == false
         continue-on-error: true
-        uses: tsickert/discord-webhook@v5.3.0
+        uses: Ilshidur/action-discord@master
+        env:
+          DISCORD_WEBHOOK: '${{ secrets.DISCORD_WEBHOOK }}?thread_id="1330422313769893938"'
         with:
-          webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
-          thread-id: 1330422313769893938
-          content: |
+          args: |
             ${{ github.event.action == 'opened' && '🆕 New PR:' || '🔄 PR Updated:' }} ${{ github.event.pull_request.html_url }}
 
       - name: Discord PR Merged Notification
         if: github.event.pull_request.merged == true && github.event.pull_request.draft == false
-        uses: tsickert/discord-webhook@v5.3.0
+        uses: Ilshidur/action-discord@master
+        env:
+          DISCORD_WEBHOOK: '${{ secrets.DISCORD_WEBHOOK }}?thread_id="1330422313769893938"'
         with:
-          webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
-          thread-id: 1330422313769893938
-          content: |
+          args: |
             🎉 PR Merged: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/pr-discord-notification.yml
+++ b/.github/workflows/pr-discord-notification.yml
@@ -14,18 +14,16 @@ jobs:
       - name: Discord PR Notification
         if: github.event.pull_request.draft == false
         continue-on-error: true
-        uses: hugoalh/send-discord-webhook-ghaction@v6.0.0
+        uses: tsickert/discord-webhook@v6.0.0
         with:
-          webhook: ${{ secrets.DISCORD_WEBHOOK }}
-          thread: 1330422313769893938
-          content: |
-            ${{ github.event.action == 'opened' && '🆕 New PR:' || '🔄 PR Updated:' }} ${{ github.event.pull_request.html_url }}
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
+          thread-id: "1330422313769893938"
+          content: ${{ github.event.action == 'opened' && '🆕 New PR:' || '🔄 PR Updated:' }} ${{ github.event.pull_request.html_url }}
 
       - name: Discord PR Merged Notification
         if: github.event.pull_request.merged == true && github.event.pull_request.draft == false
-        uses: hugoalh/send-discord-webhook-ghaction@v6.0.0
+        uses: tsickert/discord-webhook@v6.0.0
         with:
-          webhook: ${{ secrets.DISCORD_WEBHOOK }}
-          thread: 1330422313769893938
-          content: |
-            🎉 PR Merged: ${{ github.event.pull_request.html_url }}
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
+          thread-id: "1330422313769893938"
+          content: 🎉 PR Merged: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/pr-discord-notification.yml
+++ b/.github/workflows/pr-discord-notification.yml
@@ -17,14 +17,23 @@ jobs:
         with:
           webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
           thread-id: "1330422313769893938"
-          content: ""  # Empty content, using embed instead
+          content: ""
           embed-title: ${{ github.event.action == 'opened' && '🆕 New Pull Request' || '🔄 Pull Request Updated' }}
-          embed-description: ${{ github.event.pull_request.title }}
+          embed-description: |
+            **Title:** ${{ github.event.pull_request.title }}
+
+            **Branch:** `${{ github.event.pull_request.head.ref }}` → `${{ github.event.pull_request.base.ref }}`
+            **Changes:** +${{ github.event.pull_request.additions }} -${{ github.event.pull_request.deletions }}
+            **Files Changed:** ${{ github.event.pull_request.changed_files }}
+
+            ${{ github.event.pull_request.body }}
           embed-url: ${{ github.event.pull_request.html_url }}
           embed-color: ${{ github.event.action == 'opened' && '5763719' || '15844367' }}
           embed-author-name: ${{ github.event.pull_request.user.login }}
           embed-author-url: ${{ github.event.pull_request.user.html_url }}
           embed-author-icon-url: ${{ github.event.pull_request.user.avatar_url }}
+          embed-footer-text: "Repository: ${{ github.repository }}"
+          embed-timestamp: ${{ github.event.pull_request.updated_at }}
           wait: true
 
       - name: Create PR merged notification
@@ -33,12 +42,22 @@ jobs:
         with:
           webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
           thread-id: "1330422313769893938"
-          content: ""  # Empty content, using embed instead
+          content: ""
           embed-title: "🎉 Pull Request Merged"
-          embed-description: ${{ github.event.pull_request.title }}
+          embed-description: |
+            **Title:** ${{ github.event.pull_request.title }}
+
+            **Branch:** `${{ github.event.pull_request.head.ref }}` → `${{ github.event.pull_request.base.ref }}`
+            **Changes:** +${{ github.event.pull_request.additions }} -${{ github.event.pull_request.deletions }}
+            **Files Changed:** ${{ github.event.pull_request.changed_files }}
+
+            **Merged by:** ${{ github.event.pull_request.merged_by.login }}
+            **Merge Commit:** ${{ github.event.pull_request.merge_commit_sha }}
           embed-url: ${{ github.event.pull_request.html_url }}
-          embed-color: "3066993"  # Green color
-          embed-author-name: ${{ github.event.pull_request.merged_by.login }}
-          embed-author-url: ${{ github.event.pull_request.merged_by.html_url }}
-          embed-author-icon-url: ${{ github.event.pull_request.merged_by.avatar_url }}
+          embed-color: "3066993"
+          embed-author-name: ${{ github.event.pull_request.user.login }}
+          embed-author-url: ${{ github.event.pull_request.user.html_url }}
+          embed-author-icon-url: ${{ github.event.pull_request.user.avatar_url }}
+          embed-footer-text: "Repository: ${{ github.repository }}"
+          embed-timestamp: ${{ github.event.pull_request.merged_at }}
           wait: true

--- a/.github/workflows/pr-discord-notification.yml
+++ b/.github/workflows/pr-discord-notification.yml
@@ -15,12 +15,12 @@ jobs:
         if: github.event.pull_request.draft == false
         uses: tsickert/discord-webhook@v6.0.0
         with:
-          webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
+          webhook-url: ${{ secrets.DEV_PR_DISCORD_WEBHOOK }}
           thread-id: "1330422313769893938"
           username: "PR Bot"
           avatar-url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
           content: |
-            ${{ github.event.action == 'opened' && '🆕 New PR:' || '🔄 PR Updated:' }} ${{ github.event.pull_request.html_url }}
+            <@&1315850473391001674> ${{ github.event.action == 'opened' && '🆕 New PR:' || '🔄 PR Updated:' }} ${{ github.event.pull_request.html_url }}
             **Title:** ${{ github.event.pull_request.title }}
             **Author:** ${{ github.event.pull_request.user.login }}
 
@@ -28,11 +28,11 @@ jobs:
         if: github.event.pull_request.merged == true && github.event.pull_request.draft == false
         uses: tsickert/discord-webhook@v6.0.0
         with:
-          webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
+          webhook-url: ${{ secrets.DEV_PR_DISCORD_WEBHOOK }}
           thread-id: "1330422313769893938"
           username: "PR Bot"
           avatar-url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
           content: |
-            🎉 PR Merged: ${{ github.event.pull_request.html_url }}
+            <@&1315850473391001674> 🎉 PR Merged: ${{ github.event.pull_request.html_url }}
             **Title:** ${{ github.event.pull_request.title }}
             **Merged by:** ${{ github.event.pull_request.merged_by.login }}

--- a/.github/workflows/pr-discord-notification.yml
+++ b/.github/workflows/pr-discord-notification.yml
@@ -1,13 +1,22 @@
 name: PR Discord Notification
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize, closed]
 
 jobs:
   notify:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
+      - name: Debug Event
+        run: |
+          echo "Event name: ${{ github.event_name }}"
+          echo "Action: ${{ github.event.action }}"
+          echo "PR state: ${{ github.event.pull_request.state }}"
+          echo "Is draft: ${{ github.event.pull_request.draft }}"
+
       - name: Discord PR Notification
         if: github.event.pull_request.draft == false
         uses: tsickert/discord-webhook@v6.0.0

--- a/.github/workflows/pr-discord-notification.yml
+++ b/.github/workflows/pr-discord-notification.yml
@@ -1,7 +1,7 @@
 name: PR Discord Notification
 
 on:
-  workflow_dispatch:  # Allow manual trigger for testing
+  workflow_dispatch:
   pull_request:
     types: [opened, reopened, synchronize, closed]
 
@@ -18,22 +18,24 @@ jobs:
           webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
           thread-id: "1330422313769893938"
           content: ""
-          embed-title: ${{ github.event.action == 'opened' && '🆕 New Pull Request' || '🔄 Pull Request Updated' }}
+          embed-title: ${{ github.event.pull_request.title }}
           embed-description: |
-            **Title:** ${{ github.event.pull_request.title }}
+            **Repository**
+            ${{ github.repository }}
 
-            **Branch:** `${{ github.event.pull_request.head.ref }}` → `${{ github.event.pull_request.base.ref }}`
-            **Changes:** +${{ github.event.pull_request.additions }} -${{ github.event.pull_request.deletions }}
-            **Files Changed:** ${{ github.event.pull_request.changed_files }}
+            **Ref**
+            refs/pull/${{ github.event.pull_request.number }}/merge
 
-            ${{ github.event.pull_request.body }}
+            **Event** - pull_request
+            #${{ github.event.pull_request.number }} ${{ github.event.pull_request.title }}
+
+            **Triggered by**
+            ${{ github.event.pull_request.user.login }}
+
+            **Workflow**
+            PR Discord Notification
           embed-url: ${{ github.event.pull_request.html_url }}
-          embed-color: ${{ github.event.action == 'opened' && '5763719' || '15844367' }}
-          embed-author-name: ${{ github.event.pull_request.user.login }}
-          embed-author-url: ${{ github.event.pull_request.user.html_url }}
-          embed-author-icon-url: ${{ github.event.pull_request.user.avatar_url }}
-          embed-footer-text: "Repository: ${{ github.repository }}"
-          embed-timestamp: ${{ github.event.pull_request.updated_at }}
+          embed-color: "5793E6"
           wait: true
 
       - name: Create PR merged notification
@@ -43,21 +45,22 @@ jobs:
           webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
           thread-id: "1330422313769893938"
           content: ""
-          embed-title: "🎉 Pull Request Merged"
+          embed-title: "Success: PR Discord Notification"
           embed-description: |
-            **Title:** ${{ github.event.pull_request.title }}
+            **Repository**
+            ${{ github.repository }}
 
-            **Branch:** `${{ github.event.pull_request.head.ref }}` → `${{ github.event.pull_request.base.ref }}`
-            **Changes:** +${{ github.event.pull_request.additions }} -${{ github.event.pull_request.deletions }}
-            **Files Changed:** ${{ github.event.pull_request.changed_files }}
+            **Ref**
+            refs/pull/${{ github.event.pull_request.number }}/merge
 
-            **Merged by:** ${{ github.event.pull_request.merged_by.login }}
-            **Merge Commit:** ${{ github.event.pull_request.merge_commit_sha }}
+            **Event** - pull_request
+            #${{ github.event.pull_request.number }} ${{ github.event.pull_request.title }}
+
+            **Triggered by**
+            ${{ github.event.pull_request.merged_by.login }}
+
+            **Workflow**
+            PR Discord Notification
           embed-url: ${{ github.event.pull_request.html_url }}
-          embed-color: "3066993"
-          embed-author-name: ${{ github.event.pull_request.user.login }}
-          embed-author-url: ${{ github.event.pull_request.user.html_url }}
-          embed-author-icon-url: ${{ github.event.pull_request.user.avatar_url }}
-          embed-footer-text: "Repository: ${{ github.repository }}"
-          embed-timestamp: ${{ github.event.pull_request.merged_at }}
+          embed-color: "3BA55D"
           wait: true

--- a/.github/workflows/pr-discord-notification.yml
+++ b/.github/workflows/pr-discord-notification.yml
@@ -14,18 +14,44 @@ jobs:
       - name: Discord PR Notification
         if: github.event.pull_request.draft == false
         continue-on-error: true
-        uses: Ilshidur/action-discord@master
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}?thread_id=1330422313769893938
+        uses: actions/github-script@v6
         with:
-          args: |
-            ${{ github.event.action == 'opened' && '🆕 New PR:' || '🔄 PR Updated:' }} ${{ github.event.pull_request.html_url }}
+          script: |
+            const webhook = process.env.DISCORD_WEBHOOK;
+            const threadId = '1330422313769893938';
+            const message = `${{ github.event.action == 'opened' && '🆕 New PR:' || '🔄 PR Updated:' }} ${{ github.event.pull_request.html_url }}`;
+
+            await fetch(`${webhook}/messages`, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              body: JSON.stringify({
+                content: message,
+                thread_id: threadId
+              })
+            });
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
 
       - name: Discord PR Merged Notification
         if: github.event.pull_request.merged == true && github.event.pull_request.draft == false
-        uses: Ilshidur/action-discord@master
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}?thread_id=1330422313769893938
+        uses: actions/github-script@v6
         with:
-          args: |
-            🎉 PR Merged: ${{ github.event.pull_request.html_url }}
+          script: |
+            const webhook = process.env.DISCORD_WEBHOOK;
+            const threadId = '1330422313769893938';
+            const message = `🎉 PR Merged: ${{ github.event.pull_request.html_url }}`;
+
+            await fetch(`${webhook}/messages`, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              body: JSON.stringify({
+                content: message,
+                thread_id: threadId
+              })
+            });
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/pr-discord-notification.yml
+++ b/.github/workflows/pr-discord-notification.yml
@@ -17,10 +17,10 @@ jobs:
         with:
           webhook-url: ${{ secrets.DEV_PR_DISCORD_WEBHOOK }}
           thread-id: "1330422313769893938"
-          username: "PR Bot"
-          avatar-url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
+          username: "Server PR Bot"
           content: |
-            <@&1315850473391001674> ${{ github.event.action == 'opened' && '🆕 New PR:' || '🔄 PR Updated:' }} ${{ github.event.pull_request.html_url }}
+            <@&1315850473391001674>
+            ${{ github.event.action == 'opened' && '🆕 New PR:' || '🔄 PR Updated:' }} ${{ github.event.pull_request.html_url }}
             **Title:** ${{ github.event.pull_request.title }}
             **Author:** ${{ github.event.pull_request.user.login }}
 
@@ -30,9 +30,9 @@ jobs:
         with:
           webhook-url: ${{ secrets.DEV_PR_DISCORD_WEBHOOK }}
           thread-id: "1330422313769893938"
-          username: "PR Bot"
-          avatar-url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
+          username: "ServerPR Bot"
           content: |
-            <@&1315850473391001674> 🎉 PR Merged: ${{ github.event.pull_request.html_url }}
+            <@&1315850473391001674>
+            🎉 PR Merged: ${{ github.event.pull_request.html_url }}
             **Title:** ${{ github.event.pull_request.title }}
             **Merged by:** ${{ github.event.pull_request.merged_by.login }}

--- a/.github/workflows/pr-discord-notification.yml
+++ b/.github/workflows/pr-discord-notification.yml
@@ -19,10 +19,9 @@ jobs:
           thread-id: "1330422313769893938"
           username: "Server PR Bot"
           content: |
-            <@&1315850473391001674>
             ${{ github.event.action == 'opened' && '🆕 New PR:' || '🔄 PR Updated:' }} ${{ github.event.pull_request.html_url }}
             **Title:** ${{ github.event.pull_request.title }}
-            **Author:** ${{ github.event.pull_request.user.login }}
+            <@&1315850473391001674>
 
       - name: Create PR merged notification
         if: github.event.pull_request.merged == true && github.event.pull_request.draft == false
@@ -32,7 +31,7 @@ jobs:
           thread-id: "1330422313769893938"
           username: "ServerPR Bot"
           content: |
-            <@&1315850473391001674>
             🎉 PR Merged: ${{ github.event.pull_request.html_url }}
             **Title:** ${{ github.event.pull_request.title }}
             **Merged by:** ${{ github.event.pull_request.merged_by.login }}
+            <@&1315850473391001674>

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 ##
 ## Get latest from `dotnet new gitignore`
 
+# secrets file for discord webhook
+.secrets
+
 # dotenv files
 .env
 


### PR DESCRIPTION
# Discord Webhook Integration for PR Notifications

This PR implements Discord webhook integration to automatically notify the team about new PRs in a dedicated thread.

## Key Changes:
- Added GitHub Actions workflow for PR notifications
- Configured webhook to post in specific Discord thread
- Notifications for PR events: opened, updated, and merged
- Simplified notification format leveraging Discord's link preview
- Excluded draft PRs from notifications

## Test Method:
- Local testing performed using GitHub Actions
- Verified notifications appear in correct Discord thread
- Confirmed all PR states trigger appropriate notifications

## Related Ticket
[JIRA Ticket: IF-186](https://dext.atlassian.net/jira/software/c/projects/IF/boards/26?selectedIssue=IF-186)