### PR TITLE
fix: switch name and email position when pass parameters

### DIFF
--- a/src/InnovateFuture.Application/Profiles/Commands/UpdateProfile/UpdateProfileCommandValidator.cs
+++ b/src/InnovateFuture.Application/Profiles/Commands/UpdateProfile/UpdateProfileCommandValidator.cs
@@ -7,14 +7,30 @@ public class UpdateProfileCommandValidator : AbstractValidator<UpdateProfileComm
     {
         RuleFor(x => x.ProfileId)
             .NotEmpty().WithMessage("Profile Id is required.");
-        RuleFor(x => x.Email)
-            .MaximumLength(255).WithMessage("Email must not exceed 255 characters.")
-            .EmailAddress().WithMessage("Kindly enter a valid Email Address.");
-        RuleFor(x => x.Name)
-            .MaximumLength(255).WithMessage("Name must not exceed 255 characters.");
-        RuleFor(x => x.Phone)
-            .Matches("^\\+61\\s4\\d{8}$").WithMessage("Kindly enter a valid AU Phone Number.");
-        RuleFor(x => x.AvatarUrl)
-            .MaximumLength(500).WithMessage("Avatar must not exceed 500 characters.");
+        
+        When(x => !string.IsNullOrEmpty(x.Email), () =>
+        {
+            RuleFor(x => x.Email)
+                .MaximumLength(255).WithMessage("Email must not exceed 255 characters.")
+                .EmailAddress().WithMessage("Kindly enter a valid Email Address.");
+        });
+        
+        When(x => !string.IsNullOrEmpty(x.Name), () =>
+        {
+            RuleFor(x => x.Name)
+                .MaximumLength(255).WithMessage("Name must not exceed 255 characters.");
+        });
+        
+        When(x => !string.IsNullOrEmpty(x.Phone), () =>
+        {
+            RuleFor(x => x.Phone)
+                .Matches("^\\+61\\s4\\d{8}$").WithMessage("Kindly enter a valid AU Phone Number.");
+        });
+        
+        When(x => !string.IsNullOrEmpty(x.AvatarUrl), () =>
+        {
+            RuleFor(x => x.AvatarUrl)
+                .MaximumLength(500).WithMessage("Avatar url must not exceed 500 characters.");
+        });
     }
 }

--- a/src/InnovateFuture.Application/Profiles/Commands/UpdateProfile/UpdateProfileHandler.cs
+++ b/src/InnovateFuture.Application/Profiles/Commands/UpdateProfile/UpdateProfileHandler.cs
@@ -18,8 +18,8 @@ public class UpdateProfileHandler : IRequestHandler<UpdateProfileCommand, Guid>
         
         // update
         profile.UpdateProfile(
-            command.Name,
             command.Email,
+            command.Name,
             command.Phone,
             command.AvatarUrl,
             command.IsActive,


### PR DESCRIPTION
This PR fixed issue of mismatching name and email fields in profile update handler, and fixed validator of updateRequest validator.

**Key Changes:**

- switch position of name and email when passing parameters into update method.
- add a condition of checking null or empty before applying validate rule.

**Test Method:**

- manual testing

**Related Ticket**

[JIRA Ticket: IF-259](https://dext.atlassian.net/jira/software/c/projects/IF/boards/26?selectedIssue=IF-259)
