### PR TITLE
Refactor/if 270 be refactor search content as rearch key

### DIFF
--- a/src/InnovateFuture.Api/Controllers/OrganisationsController/QueryOrganisationsRequest.cs
+++ b/src/InnovateFuture.Api/Controllers/OrganisationsController/QueryOrganisationsRequest.cs
@@ -6,13 +6,13 @@ namespace InnovateFuture.Api.Controllers.OrganisationsController;
 
 public class QueryOrganisationsRequest :IPaginatedRequest<QueryOrganisationsFilters> {
     public QueryOrganisationsFilters? Filters { get; set; }
+    public string? SearchKey { get; set; }
     public Sorting[]? Sortings { get; set; }
     public int? Offset { get; set; }
     public int Limit { get; set; }
 }
 public class QueryOrganisationsFilters
 {
-    public string? OrgNameOrEmail { get; set; }
     public StatusEnum? Status { get; set; } 
     public SubscriptionEnum? Subscription { get; set; }
 }

--- a/src/InnovateFuture.Api/Controllers/ProfilesController/GetProfileWithDetailsResponse.cs
+++ b/src/InnovateFuture.Api/Controllers/ProfilesController/GetProfileWithDetailsResponse.cs
@@ -22,7 +22,7 @@ public class GetProfileWithDetailsResponse
     public string? Phone { get; set; }
     public string? AvatarUrl { get; set; }
     public GetOrganisationsResponse? Organisation { get; set; }
-    public GetProfileResponse? InviterProfile { get; set; }    
+    public GetProfileResponse? InviterProfile { get; set; }   
     public GetProfileResponse? SupervisorProfile { get; set; }
     public DateTime CreatedAt{ get;  set; }
     public DateTime UpdatedAt { get;  set; }

--- a/src/InnovateFuture.Api/Controllers/ProfilesController/ProfilesController.cs
+++ b/src/InnovateFuture.Api/Controllers/ProfilesController/ProfilesController.cs
@@ -48,11 +48,14 @@ public class ProfilesController : ControllerBase
     /// <returns></returns>
     [AllowAnonymous]
     [HttpGet("{id}")]
-    public async Task<IActionResult> GetProfile(Guid id)
+    public async Task<IActionResult> GetProfile(Guid id,[FromQuery] bool includeDetails=false)
     {
         var query = new GetProfileQuery { ProfileId = id };
         var profile = await _mediator.Send(query);
-        var profileResponse =  _mapper.Map<GetProfileWithDetailsResponse>(profile);
+        
+        var profileResponse =  includeDetails? (object)_mapper.Map<GetProfileWithDetailsResponse>(profile):
+            _mapper.Map<GetProfileResponse>(profile);
+        
         return Ok(profileResponse);
     }
 
@@ -68,10 +71,10 @@ public class ProfilesController : ControllerBase
         var query = _mapper.Map<GetProfilesQuery>(request);
         var paginatedProfiles = await _mediator.Send(query);
         
-        var response = request.IncludeDetails ?? false
+        var profilesResponse = request.IncludeDetails ?? false
             ? (object)_mapper.Map<GetProfileWithDetailsPaginatedResponse>(paginatedProfiles)
             : _mapper.Map<GetProfilePaginatedResponse>(paginatedProfiles);
         
-        return Ok(response);
+        return Ok(profilesResponse);
     }
 }

--- a/src/InnovateFuture.Api/Controllers/ProfilesController/ProfilesController.cs
+++ b/src/InnovateFuture.Api/Controllers/ProfilesController/ProfilesController.cs
@@ -52,7 +52,7 @@ public class ProfilesController : ControllerBase
     {
         var query = new GetProfileQuery { ProfileId = id };
         var profile = await _mediator.Send(query);
-        var profileResponse =  _mapper.Map<GetProfileResponse>(profile);
+        var profileResponse =  _mapper.Map<GetProfileWithDetailsResponse>(profile);
         return Ok(profileResponse);
     }
 

--- a/src/InnovateFuture.Api/Controllers/ProfilesController/QueryProfilesRequest.cs
+++ b/src/InnovateFuture.Api/Controllers/ProfilesController/QueryProfilesRequest.cs
@@ -5,6 +5,7 @@ namespace InnovateFuture.Api.Controllers.ProfilesController;
 public class QueryProfilesRequest : IPaginatedRequest<QueryProfileFilters>
 {
     public QueryProfileFilters? Filters { get; set; }
+    public string? SearchKey { get; set; }
     public Sorting[]? Sortings { get; set; }
     public int? Offset { get; set; }
     public int Limit { get; set; }
@@ -13,7 +14,6 @@ public class QueryProfilesRequest : IPaginatedRequest<QueryProfileFilters>
 
 public class QueryProfileFilters
 {
-    public string? NameOrEmailOrPhone { get; set; }
     public string? RoleIds { get; set; }
     public Guid? OrgId { get; set; }
     public bool? IsActive { get; set; }

--- a/src/InnovateFuture.Api/Controllers/ProfilesController/QueryProfilesRequest.cs
+++ b/src/InnovateFuture.Api/Controllers/ProfilesController/QueryProfilesRequest.cs
@@ -14,7 +14,7 @@ public class QueryProfilesRequest : IPaginatedRequest<QueryProfileFilters>
 public class QueryProfileFilters
 {
     public string? NameOrEmailOrPhone { get; set; }
-    public Guid? RoleId { get; set; }
+    public string? RoleIds { get; set; }
     public Guid? OrgId { get; set; }
     public bool? IsActive { get; set; }
     public bool? IsConfirmed { get; set; }

--- a/src/InnovateFuture.Application/Common/Models/IPaginatedRequest.cs
+++ b/src/InnovateFuture.Application/Common/Models/IPaginatedRequest.cs
@@ -2,7 +2,8 @@ namespace InnovateFuture.Application.Common.Models;
 
 public interface IPaginatedRequest<TFilters>
 {
-     TFilters Filters { get; set; }
+     TFilters? Filters { get; set; }
+     string? SearchKey  { get; set; }
      Sorting[]? Sortings { get; set; }
      int? Offset { get; set; }
      int Limit { get; set; }

--- a/src/InnovateFuture.Application/InnovateFuture.Application.csproj
+++ b/src/InnovateFuture.Application/InnovateFuture.Application.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="11.11.0" />
+    <PackageReference Include="LinqKit.Microsoft.EntityFrameworkCore" Version="8.1.8" />
     <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="MediatR.Contracts" Version="2.0.1" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />

--- a/src/InnovateFuture.Application/Organisations/Queries/GetOrganisations/GetOrganisationsHandler.cs
+++ b/src/InnovateFuture.Application/Organisations/Queries/GetOrganisations/GetOrganisationsHandler.cs
@@ -33,15 +33,15 @@ public class GetOrganisationsHandler : IRequestHandler<GetOrganisationsQuery, (L
                 // Build predicate based on query conditions
                 predicate = predicate.And(o =>
                     (!filters.Status.HasValue || o.Status == filters.Status) &&
-                    (!filters.Subscription.HasValue || o.Subscription == filters.Subscription)
-                    );
+                    (!filters.Subscription.HasValue || o.Subscription == filters.Subscription));
             }
 
             if (!string.IsNullOrEmpty(query.SearchKey))
             {
                 var searchKey = query.SearchKey;
-                predicate = predicate.And(o=>( o.OrgName.Contains(searchKey) || 
-                                               (!string.IsNullOrEmpty(o.Email) && o.Email.Contains(searchKey)) ));
+                predicate = predicate.And(o=>
+                     (o.OrgName.Contains(searchKey) || 
+                     (!string.IsNullOrEmpty(o.Email) && o.Email.Contains(searchKey))));
             }
 
             if (query.Sortings!=null && query.Sortings!.Length>0)

--- a/src/InnovateFuture.Application/Organisations/Queries/GetOrganisations/GetOrganisationsHandler.cs
+++ b/src/InnovateFuture.Application/Organisations/Queries/GetOrganisations/GetOrganisationsHandler.cs
@@ -2,6 +2,8 @@ using System.Linq.Expressions;
 using MediatR;
 using InnovateFuture.Domain.Entities;
 using InnovateFuture.Infrastructure.Organisations.Persistence.Interfaces;
+using LinqKit;
+
 
 namespace InnovateFuture.Application.Organisations.Queries.GetOrganisations;
 
@@ -16,7 +18,9 @@ public class GetOrganisationsHandler : IRequestHandler<GetOrganisationsQuery, (L
 
     public async Task<(List<Organisation> data, int totalItems)> Handle(GetOrganisationsQuery query, CancellationToken cancellationToken)
     {
-        Expression<Func<Organisation, bool>>? queryPredicate=null;
+        
+        var predicate = PredicateBuilder.New<Organisation>();
+        
         string? queryOrderBy=null;
             
         var queriesEmpty = query.GetType().GetProperties().All(p=>p.GetValue(query)==null);
@@ -27,11 +31,17 @@ public class GetOrganisationsHandler : IRequestHandler<GetOrganisationsQuery, (L
             {
                 var filters = query.Filters;
                 // Build predicate based on query conditions
-                queryPredicate = o =>
-                    (string.IsNullOrEmpty(filters.OrgNameOrEmail) || o.OrgName.Contains(filters.OrgNameOrEmail) || 
-                     (!string.IsNullOrEmpty(o.Email) && o.Email!.Contains(filters.OrgNameOrEmail)) )&&
-                    (!filters.Status.HasValue || o.Status == filters.Status)&&
-                    (!filters.Subscription.HasValue || o.Subscription == filters.Subscription);
+                predicate = predicate.And(o =>
+                    (!filters.Status.HasValue || o.Status == filters.Status) &&
+                    (!filters.Subscription.HasValue || o.Subscription == filters.Subscription)
+                    );
+            }
+
+            if (!string.IsNullOrEmpty(query.SearchKey))
+            {
+                var searchKey = query.SearchKey;
+                predicate = predicate.And(o=>( o.OrgName.Contains(searchKey) || 
+                                               (!string.IsNullOrEmpty(o.Email) && o.Email.Contains(searchKey)) ));
             }
 
             if (query.Sortings!=null && query.Sortings!.Length>0)
@@ -45,7 +55,7 @@ public class GetOrganisationsHandler : IRequestHandler<GetOrganisationsQuery, (L
             }
         }
         
-        var (data,totalItems) = await _orgRepository.GetAnyAsync(queryPredicate,query.Limit,query.Offset??0,queryOrderBy);
+        var (data,totalItems) = await _orgRepository.GetAnyAsync(predicate,query.Limit,query.Offset??0,queryOrderBy);
 
         return (data, totalItems);
     }

--- a/src/InnovateFuture.Application/Organisations/Queries/GetOrganisations/GetOrganisationsHandler.cs
+++ b/src/InnovateFuture.Application/Organisations/Queries/GetOrganisations/GetOrganisationsHandler.cs
@@ -19,7 +19,7 @@ public class GetOrganisationsHandler : IRequestHandler<GetOrganisationsQuery, (L
     public async Task<(List<Organisation> data, int totalItems)> Handle(GetOrganisationsQuery query, CancellationToken cancellationToken)
     {
         
-        var predicate = PredicateBuilder.New<Organisation>();
+        var predicate = PredicateBuilder.New<Organisation>(true);
         
         string? queryOrderBy=null;
             

--- a/src/InnovateFuture.Application/Organisations/Queries/GetOrganisations/GetOrganisationsQuery.cs
+++ b/src/InnovateFuture.Application/Organisations/Queries/GetOrganisations/GetOrganisationsQuery.cs
@@ -8,6 +8,7 @@ namespace InnovateFuture.Application.Organisations.Queries.GetOrganisations;
 public class  GetOrganisationsQuery : IRequest<(List<Organisation> data, int totalItems)>
 {
     public QueryOrganisationsFilters? Filters { get; set; }
+    public string? SearchKey { get; set; }
     public Sorting[]? Sortings { get; set; }
     public int? Offset { get; set; }
     public int Limit { get; set; }
@@ -15,7 +16,6 @@ public class  GetOrganisationsQuery : IRequest<(List<Organisation> data, int tot
 
 public class QueryOrganisationsFilters
 {
-    public string? OrgNameOrEmail { get; set; }
     public StatusEnum? Status { get; set; } 
     public SubscriptionEnum? Subscription { get; set; }
 }

--- a/src/InnovateFuture.Application/Organisations/Queries/GetOrganisations/GetOrganisationsQueryValidator.cs
+++ b/src/InnovateFuture.Application/Organisations/Queries/GetOrganisations/GetOrganisationsQueryValidator.cs
@@ -5,13 +5,11 @@ public class GetOrganisationsQueryValidator : AbstractValidator<GetOrganisations
 {
     public GetOrganisationsQueryValidator()
     { 
-        When(x => x.Filters != null, () =>
-        {
-            RuleFor(x => x.Filters!.OrgNameOrEmail)
-                .MaximumLength(100).WithMessage("Organisation name must not exceed 100 characters.")
-                .When(x => x.Filters!=null&&!string.IsNullOrEmpty(x.Filters.OrgNameOrEmail));
-        });
-
+        
+        RuleFor(x => x.SearchKey)
+            .MaximumLength(100).WithMessage("Search content must not exceed 100 characters.")
+            .When(x => !string.IsNullOrEmpty(x.SearchKey));
+            
         RuleFor(x => x.Limit)
             .GreaterThan(0).WithMessage("Limit must be greater than zero.");
         

--- a/src/InnovateFuture.Application/Profiles/Queries/GetProfiles/GetProfilesHandler.cs
+++ b/src/InnovateFuture.Application/Profiles/Queries/GetProfiles/GetProfilesHandler.cs
@@ -3,6 +3,7 @@ using InnovateFuture.Application.Common.Models;
 using MediatR;
 using InnovateFuture.Domain.Entities;
 using InnovateFuture.Infrastructure.Profiles.Persistence.Interfaces;
+using LinqKit;
 
 namespace InnovateFuture.Application.Profiles.Queries.GetProfiles;
 
@@ -17,7 +18,7 @@ public class GetProfilesHandler : IRequestHandler<GetProfilesQuery, (List<Profil
 
     public async Task<(List<Profile> data, int totalItems)> Handle(GetProfilesQuery query, CancellationToken cancellationToken)
     {
-        Expression<Func<Profile, bool>>? queryPredicate = null;
+        var predicate = PredicateBuilder.New<Profile>();
         string? queryOrderBy = null;
         
         var queriesEmpty = query.GetType().GetProperties().All(p => p.GetValue(query) == null);
@@ -35,17 +36,21 @@ public class GetProfilesHandler : IRequestHandler<GetProfilesQuery, (List<Profil
                     .Select(Guid.Parse)
                     .ToList();
                 
-                queryPredicate = p =>
-                    (string.IsNullOrEmpty(filters.NameOrEmailOrPhone) || 
-                     (!string.IsNullOrEmpty(p.Name) && p.Name.Contains(filters.NameOrEmailOrPhone)) ||
-                    (!string.IsNullOrEmpty(p.Email) && p.Email.Contains(filters.NameOrEmailOrPhone)) ||
-                    (!string.IsNullOrEmpty(p.Phone) && p.Phone.Contains(filters.NameOrEmailOrPhone))) &&
+                predicate = predicate.And(p =>
                     (filters.OrgId==null || p.OrgId==filters.OrgId) &&
-                    (validGuids.Contains(p.RoleId)) &&
+                    (validGuids.Count==0||validGuids.Contains(p.RoleId)) &&
                     (!filters.IsConfirmed.HasValue || p.IsConfirmed == filters.IsConfirmed) &&
-                    (!filters.IsActive.HasValue || p.IsActive == filters.IsActive);
+                    (!filters.IsActive.HasValue || p.IsActive == filters.IsActive));
             }
 
+            if (!string.IsNullOrEmpty(query.SearchKey))
+            {
+                var searchKeys = query.SearchKey;
+                predicate = predicate.And((p=> 
+                                                (!string.IsNullOrEmpty(p.Name) && p.Name.Contains(searchKeys)) ||
+                                                (!string.IsNullOrEmpty(p.Email) && p.Email.Contains(searchKeys)) ||
+                                                (!string.IsNullOrEmpty(p.Phone) && p.Phone.Contains(searchKeys))));
+            }
             if (query.Sortings != null && query.Sortings!.Length>0)
             {
                 foreach (var sorting in query.Sortings)
@@ -57,7 +62,7 @@ public class GetProfilesHandler : IRequestHandler<GetProfilesQuery, (List<Profil
             }
         }
         
-        var (data, totalItems) = await _profileRepository.GetAnyAsync(queryPredicate, query.Limit, query.Offset ?? 0, queryOrderBy);
+        var (data, totalItems) = await _profileRepository.GetAnyAsync(predicate, query.Limit, query.Offset ?? 0, queryOrderBy);
         
         return (data, totalItems);
     }

--- a/src/InnovateFuture.Application/Profiles/Queries/GetProfiles/GetProfilesHandler.cs
+++ b/src/InnovateFuture.Application/Profiles/Queries/GetProfiles/GetProfilesHandler.cs
@@ -27,13 +27,21 @@ public class GetProfilesHandler : IRequestHandler<GetProfilesQuery, (List<Profil
             if (query.Filters != null)
             {
                 var filters = query.Filters;
+                
+                var roleIds = filters.RoleIds?.Split(",")??[];
+                
+                var validGuids = roleIds
+                    .Where(s => Guid.TryParse(s, out _))
+                    .Select(Guid.Parse)
+                    .ToList();
+                
                 queryPredicate = p =>
                     (string.IsNullOrEmpty(filters.NameOrEmailOrPhone) || 
                      (!string.IsNullOrEmpty(p.Name) && p.Name.Contains(filters.NameOrEmailOrPhone)) ||
                     (!string.IsNullOrEmpty(p.Email) && p.Email.Contains(filters.NameOrEmailOrPhone)) ||
                     (!string.IsNullOrEmpty(p.Phone) && p.Phone.Contains(filters.NameOrEmailOrPhone))) &&
                     (filters.OrgId==null || p.OrgId==filters.OrgId) &&
-                    (filters.RoleId==null || p.RoleId==filters.RoleId) &&
+                    (validGuids.Contains(p.RoleId)) &&
                     (!filters.IsConfirmed.HasValue || p.IsConfirmed == filters.IsConfirmed) &&
                     (!filters.IsActive.HasValue || p.IsActive == filters.IsActive);
             }

--- a/src/InnovateFuture.Application/Profiles/Queries/GetProfiles/GetProfilesHandler.cs
+++ b/src/InnovateFuture.Application/Profiles/Queries/GetProfiles/GetProfilesHandler.cs
@@ -18,7 +18,7 @@ public class GetProfilesHandler : IRequestHandler<GetProfilesQuery, (List<Profil
 
     public async Task<(List<Profile> data, int totalItems)> Handle(GetProfilesQuery query, CancellationToken cancellationToken)
     {
-        var predicate = PredicateBuilder.New<Profile>();
+        var predicate = PredicateBuilder.New<Profile>(true);
         string? queryOrderBy = null;
         
         var queriesEmpty = query.GetType().GetProperties().All(p => p.GetValue(query) == null);

--- a/src/InnovateFuture.Application/Profiles/Queries/GetProfiles/GetProfilesHandler.cs
+++ b/src/InnovateFuture.Application/Profiles/Queries/GetProfiles/GetProfilesHandler.cs
@@ -38,7 +38,7 @@ public class GetProfilesHandler : IRequestHandler<GetProfilesQuery, (List<Profil
                 
                 predicate = predicate.And(p =>
                     (filters.OrgId==null || p.OrgId==filters.OrgId) &&
-                    (validGuids.Count==0||validGuids.Contains(p.RoleId)) &&
+                    (validGuids.Count==0 || validGuids.Contains(p.RoleId)) &&
                     (!filters.IsConfirmed.HasValue || p.IsConfirmed == filters.IsConfirmed) &&
                     (!filters.IsActive.HasValue || p.IsActive == filters.IsActive));
             }
@@ -47,9 +47,9 @@ public class GetProfilesHandler : IRequestHandler<GetProfilesQuery, (List<Profil
             {
                 var searchKeys = query.SearchKey;
                 predicate = predicate.And((p=> 
-                                                (!string.IsNullOrEmpty(p.Name) && p.Name.Contains(searchKeys)) ||
-                                                (!string.IsNullOrEmpty(p.Email) && p.Email.Contains(searchKeys)) ||
-                                                (!string.IsNullOrEmpty(p.Phone) && p.Phone.Contains(searchKeys))));
+                    (!string.IsNullOrEmpty(p.Name) && p.Name.Contains(searchKeys)) || 
+                    (!string.IsNullOrEmpty(p.Email) && p.Email.Contains(searchKeys)) || 
+                    (!string.IsNullOrEmpty(p.Phone) && p.Phone.Contains(searchKeys))));
             }
             if (query.Sortings != null && query.Sortings!.Length>0)
             {

--- a/src/InnovateFuture.Application/Profiles/Queries/GetProfiles/GetProfilesQuery.cs
+++ b/src/InnovateFuture.Application/Profiles/Queries/GetProfiles/GetProfilesQuery.cs
@@ -15,7 +15,7 @@ public class GetProfilesQuery : IRequest<(List<Profile> data, int totalItems)>
 public class QueryProfileFilters
 {
     public string? NameOrEmailOrPhone { get; set; }
-    public Guid? RoleId { get; set; }
+    public string? RoleIds { get; set; }
     public Guid? OrgId { get; set; }
     public bool? IsActive { get; set; }
     public bool? IsConfirmed { get; set; }

--- a/src/InnovateFuture.Application/Profiles/Queries/GetProfiles/GetProfilesQuery.cs
+++ b/src/InnovateFuture.Application/Profiles/Queries/GetProfiles/GetProfilesQuery.cs
@@ -7,6 +7,7 @@ namespace InnovateFuture.Application.Profiles.Queries.GetProfiles;
 public class GetProfilesQuery : IRequest<(List<Profile> data, int totalItems)>
 {
     public QueryProfileFilters? Filters { get; set; }
+    public string? SearchKey { get; set; }
     public Sorting[]? Sortings { get; set; }
     public int? Offset { get; set; }
     public int Limit { get; set; }
@@ -14,7 +15,6 @@ public class GetProfilesQuery : IRequest<(List<Profile> data, int totalItems)>
 
 public class QueryProfileFilters
 {
-    public string? NameOrEmailOrPhone { get; set; }
     public string? RoleIds { get; set; }
     public Guid? OrgId { get; set; }
     public bool? IsActive { get; set; }

--- a/src/InnovateFuture.Application/Profiles/Queries/GetProfiles/GetProfilesQueryValidator.cs
+++ b/src/InnovateFuture.Application/Profiles/Queries/GetProfiles/GetProfilesQueryValidator.cs
@@ -5,12 +5,9 @@ public class GetProfilesQueryValidator : AbstractValidator<GetProfilesQuery>
 {
     public GetProfilesQueryValidator()
     { 
-        When(x => x.Filters != null, () =>
-        {
-            RuleFor(x => x.Filters!.NameOrEmailOrPhone)
-                .MaximumLength(100).WithMessage("Searching content must not exceed 100 characters.")
-                .When(x => x.Filters!=null&&!string.IsNullOrEmpty(x.Filters.NameOrEmailOrPhone));
-        });
+        RuleFor(x => x.SearchKey)
+            .MaximumLength(100).WithMessage("Search content must not exceed 100 characters.")
+            .When(x => !string.IsNullOrEmpty(x.SearchKey));
 
         RuleFor(x => x.Limit)
             .GreaterThan(0).WithMessage("Limit must be greater than zero.");


### PR DESCRIPTION
This PR Refactored Filters Field nameOrEmail to searchKey in Paginated Request Interface

**Key Changes:**

- Renamed the nameOrEmail filter to searchKey for better clarity and consistency.
- Introduced a Predicate Utility Package to modularize predicate logic, making it more maintainable and reusable.
- Added a condition to include roleIds in the predicate only if GuidRoleId.Count > 0, improving query accuracy and performance.

**Test Method:**

- Performed manual testing via Swagger, covering all relevant test cases to ensure correctness.

**Related Ticket**

[JIRA Ticket: IF-270](https://dext.atlassian.net/jira/software/c/projects/IF/boards/26?selectedIssue=IF-270)
