### PR TITLE
fix: update Discord PR notification workflow to exclude merged PRs

### DIFF
--- a/.github/workflows/pr-discord-notification.yml
+++ b/.github/workflows/pr-discord-notification.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Create PR notification
-        if: github.event.pull_request.draft == false
+        if: github.event.pull_request.draft == false && !github.event.pull_request.merged
         uses: tsickert/discord-webhook@v6.0.0
         with:
           webhook-url: ${{ secrets.DEV_PR_DISCORD_WEBHOOK }}


### PR DESCRIPTION
This PR updates the Discord notification workflow to prevent duplicate notifications when a PR is merged. Previously, when merging a PR, it would trigger both an update notification and a merge notification. Now it will only show the merge notification.

**Key Changes:**

- Added condition `!github.event.pull_request.merged` to PR notification step to prevent update notifications during merge
- Kept the original notification behavior for PR updates and new PRs
- Maintained the role mention functionality (`<@&1315850473391001674>`) in notifications

**Test Method:**

- Create a new PR -> Should see "New PR" notification
- Update PR -> Should see "PR Updated" notification
- Merge PR -> Should only see "PR Merged" notification (no update notification)